### PR TITLE
Changed msgpack-python to msgpack.

### DIFF
--- a/numcodecs/msgpacks.py
+++ b/numcodecs/msgpacks.py
@@ -28,8 +28,7 @@ class MsgPack(Codec):
 
     Notes
     -----
-    Requires `msgpack-python <https://pypi.python.org/pypi/msgpack-python>`_ to be
-    installed.
+    Requires `msgpack <https://pypi.org/project/msgpack/>`_ to be installed.
 
     """
 

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -9,7 +9,7 @@ import numpy as np
 try:
     from numcodecs.msgpacks import MsgPack
 except ImportError:  # pragma: no cover
-    raise unittest.SkipTest("msgpack-python not available")
+    raise unittest.SkipTest("msgpack not available")
 
 
 from numcodecs.tests.common import (check_config, check_repr, check_encode_decode_array,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
-msgpack-python
+msgpack
 pytest

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ flake8==3.5.0
 idna==2.6
 mccabe==0.6.1
 monotonic==1.3
-msgpack-python==0.4.8
+msgpack==0.5.6
 numpy==1.13.3
 packaging==16.8
 pkginfo==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -321,7 +321,7 @@ def run_setup(with_extensions):
             'numpy>=1.7',
         ],
         extras_require={
-            'msgpack':  ["msgpack-python"],
+            'msgpack':  ["msgpack"],
         },
         ext_modules=ext_modules,
         cmdclass=cmdclass,


### PR DESCRIPTION
Changed dev requirements to point to latest version on PyPI.

Closes #74.

Did a grep for "msgpack" through the codebase and changed to point to the new package where appropriate.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py36`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
