### PR TITLE
Fix get codec

### DIFF
--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -29,6 +29,7 @@ def get_codec(config):
     Zlib(level=1)
 
     """
+    config = dict(config)
     codec_id = config.pop('id', None)
     cls = codec_registry.get(codec_id, None)
     if cls is None:

--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -241,7 +241,6 @@ def check_err_decode_object_buffer(compressor):
     out = np.empty(10, dtype=object)
     with pytest.raises(ValueError):
         compressor.decode(enc, out=out)
-    print(out[:])
 
 
 def check_err_encode_object_buffer(compressor):

--- a/numcodecs/tests/test_registry.py
+++ b/numcodecs/tests/test_registry.py
@@ -11,3 +11,11 @@ from numcodecs.registry import get_codec
 def test_registry_errors():
     with pytest.raises(ValueError):
         get_codec({'id': 'foo'})
+
+
+def test_get_codec_argument():
+    # Check that get_codec doesn't modify its argument.
+    arg = {"id": "json"}
+    before = dict(arg)
+    get_codec(arg)
+    assert before == arg


### PR DESCRIPTION
Simple fix for #78. 

Also removed a minor spam output from running tests.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py36`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
