### PR TITLE
Fix old origin URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ extensions = [
 
 numpydoc_show_class_members = False
 numpydoc_class_members_toctree = False
-issues_github_path = 'alimanfoo/numcodecs'
+issues_github_path = 'zarr-developers/numcodecs'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,7 @@ architecture::
 
 To work with Numcodecs source code in development, install from GitHub::
 
-    $ git clone --recursive https://github.com/alimanfoo/numcodecs.git
+    $ git clone --recursive https://github.com/zarr-developers/numcodecs.git
     $ cd numcodecs
     $ python setup.py install
 


### PR DESCRIPTION
Fixes the GitHub issue URLs in the changelog. Also updates the instructions.

There is one old URL remaining in the changelog related to Coveralls (when it was setup). Not sure if that is worth changing or not.

Edit: Skipped CI as it shouldn't matter here. Built the docs locally to verify the issue links worked correctly.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
