### PR TITLE
Adds a `no cover` line for the `ncores` fallback

### DIFF
--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -46,7 +46,7 @@ try:
     # initialize blosc
     try:
         ncores = multiprocessing.cpu_count()
-    except OSError:
+    except OSError:  # pragma: no cover
         ncores = 1
     blosc.init()
     blosc.set_nthreads(min(8, ncores))


### PR DESCRIPTION
Follow-up to PR ( https://github.com/zarr-developers/numcodecs/pull/93 )

Adds a `no cover` for the exception case since `cpu_count` always works for us on CI.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
