### PR TITLE
Move pip freeze

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
 install:
   - pip install -U tox-travis coveralls pip setuptools wheel
   - python setup.py build_ext --inplace
-  - pip freeze
 
 script:
   - tox

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands =
     py37: pytest -v --cov=numcodecs --doctest-modules --doctest-glob=*.pyx numcodecs
     coverage report -m
     py37: flake8 --max-line-length=100 numcodecs
+    pip freeze
 deps =
     py27: backports.lzma
     -rrequirements_dev.txt


### PR DESCRIPTION
This PR moves the ``pip freeze`` command for travis CI to within tox.ini, as environment creation and test runs is being delegated to tox.

TODO:
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
