### PR TITLE
Use old-style buffer on Python 2

### DIFF
--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -18,6 +18,7 @@ if PY2:  # pragma: py3 no cover
     binary_type = str
     integer_types = (int, long)
     reduce = reduce
+    buffer = buffer
 
 else:  # pragma: py2 no cover
 
@@ -25,6 +26,7 @@ else:  # pragma: py2 no cover
     binary_type = bytes
     integer_types = int,
     from functools import reduce
+    buffer = lambda a: a
 
 
 def buffer_tobytes(v):
@@ -33,10 +35,8 @@ def buffer_tobytes(v):
         return v
     elif isinstance(v, np.ndarray):
         return v.tobytes(order='A')
-    elif PY2:  # pragma: py3 no cover
-        v = buffer(v)
-
-    return memoryview(v).tobytes()
+    else:
+        return memoryview(buffer(v)).tobytes()
 
 
 def buffer_copy(buf, out=None):

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -18,7 +18,6 @@ if PY2:  # pragma: py3 no cover
     binary_type = str
     integer_types = (int, long)
     reduce = reduce
-    buffer = buffer
 
 else:  # pragma: py2 no cover
 
@@ -26,7 +25,6 @@ else:  # pragma: py2 no cover
     binary_type = bytes
     integer_types = int,
     from functools import reduce
-    buffer = lambda a: a
 
 
 def buffer_tobytes(v):
@@ -35,8 +33,10 @@ def buffer_tobytes(v):
         return v
     elif isinstance(v, np.ndarray):
         return v.tobytes(order='A')
-    else:
-        return memoryview(buffer(v)).tobytes()
+    elif PY2:  # pragma: py3 no cover
+        v = buffer(v)
+
+    return memoryview(v).tobytes()
 
 
 def buffer_copy(buf, out=None):

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -14,6 +14,7 @@ PY2 = sys.version_info[0] == 2
 
 if PY2:  # pragma: py3 no cover
 
+    buffer = buffer
     text_type = unicode
     binary_type = str
     integer_types = (int, long)

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -22,6 +22,7 @@ if PY2:  # pragma: py3 no cover
 
 else:  # pragma: py2 no cover
 
+    buffer = memoryview
     text_type = str
     binary_type = bytes
     integer_types = int,

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -33,8 +33,8 @@ def buffer_tobytes(v):
         return v
     elif isinstance(v, np.ndarray):
         return v.tobytes(order='A')
-    elif PY2 and isinstance(v, array.array):  # pragma: py3 no cover
-        return v.tostring()
+    elif PY2:  # pragma: py3 no cover
+        return memoryview(buffer(v)).tobytes()
     else:
         return memoryview(v).tobytes()
 

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -34,9 +34,9 @@ def buffer_tobytes(v):
     elif isinstance(v, np.ndarray):
         return v.tobytes(order='A')
     elif PY2:  # pragma: py3 no cover
-        return memoryview(buffer(v)).tobytes()
-    else:
-        return memoryview(v).tobytes()
+        v = buffer(v)
+
+    return memoryview(v).tobytes()
 
 
 def buffer_copy(buf, out=None):

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -8,7 +8,7 @@ import numpy as np
 
 
 from .abc import Codec
-from .compat import buffer_copy, handle_datetime, PY2
+from .compat import buffer, buffer_copy, handle_datetime, PY2
 
 
 class GZip(Codec):

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -8,7 +8,7 @@ import numpy as np
 
 
 from .abc import Codec
-from .compat import buffer_copy, handle_datetime, buffer_tobytes, PY2
+from .compat import buffer_copy, handle_datetime, PY2
 
 
 class GZip(Codec):
@@ -42,8 +42,8 @@ class GZip(Codec):
                 buf = buf.tobytes(order='A')
 
         if PY2:  # pragma: py3 no cover
-            # ensure bytes, PY2 cannot handle things like bytearray
-            buf = buffer_tobytes(buf)
+            # ensure buffer, PY2 cannot handle things like bytearray
+            buf = buffer(buf)
 
         # do compression
         compressed = io.BytesIO()
@@ -59,8 +59,8 @@ class GZip(Codec):
     def decode(self, buf, out=None):
 
         if PY2:  # pragma: py3 no cover
-            # ensure bytes, PY2 cannot handle things like bytearray
-            buf = buffer_tobytes(buf)
+            # ensure buffer, PY2 cannot handle things like bytearray
+            buf = buffer(buf)
 
         # do decompression
         buf = io.BytesIO(buf)

--- a/numcodecs/zlib.py
+++ b/numcodecs/zlib.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 from .abc import Codec
-from .compat import buffer_copy, handle_datetime, PY2
+from .compat import buffer, buffer_copy, handle_datetime, PY2
 
 
 class Zlib(Codec):

--- a/numcodecs/zlib.py
+++ b/numcodecs/zlib.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 from .abc import Codec
-from .compat import buffer_copy, handle_datetime, buffer_tobytes, PY2
+from .compat import buffer_copy, handle_datetime, PY2
 
 
 class Zlib(Codec):
@@ -41,8 +41,8 @@ class Zlib(Codec):
                 buf = buf.tobytes(order='A')
 
         if PY2:  # pragma: py3 no cover
-            # ensure bytes, PY2 cannot handle things like bytearray
-            buf = buffer_tobytes(buf)
+            # ensure buffer, PY2 cannot handle things like bytearray
+            buf = buffer(buf)
 
         # do compression
         return _zlib.compress(buf, self.level)
@@ -51,8 +51,8 @@ class Zlib(Codec):
     def decode(self, buf, out=None):
 
         if PY2:  # pragma: py3 no cover
-            # ensure bytes, PY2 cannot handle things like bytearray
-            buf = buffer_tobytes(buf)
+            # ensure buffer, PY2 cannot handle things like bytearray
+            buf = buffer(buf)
 
         # do decompression
         dec = _zlib.decompress(buf)


### PR DESCRIPTION
Makes use of the old-style buffer on Python 2 to more easily coerce objects to `memoryview`s on Python 2. The code here is a bit cleaner by smoothing over Python 2/3 differences. That said, it results in a ~100ns slowdown for Python 3 (due to the `lambda`) and a ~400ns slowdown for Python 2. This is pretty negligible on the grand scheme of things, but it is worth noting. Figured this might be worth discussion.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
