### PR TITLE
Use `buffer_tobytes` on non-`object` types in test

### DIFF
--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -187,8 +187,6 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
         # setup
         i = int(arr_fn.split('.')[-2])
         arr = np.load(arr_fn)
-        if arr.dtype.kind is not 'O':
-            arr_bytes = buffer_tobytes(arr)
         if arr.flags.f_contiguous:
             order = 'F'
         else:
@@ -234,7 +232,7 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
                     assert_array_items_equal(arr, dec_arr)
                 else:
                     assert_array_equal(arr, dec_arr)
-                    assert arr_bytes == buffer_tobytes(dec)
+                    assert buffer_tobytes(arr) == buffer_tobytes(dec)
 
 
 def check_err_decode_object_buffer(compressor):

--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -187,7 +187,8 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
         # setup
         i = int(arr_fn.split('.')[-2])
         arr = np.load(arr_fn)
-        arr_bytes = buffer_tobytes(arr)
+        if arr.dtype.kind is not 'O':
+            arr_bytes = buffer_tobytes(arr)
         if arr.flags.f_contiguous:
             order = 'F'
         else:


### PR DESCRIPTION
Pulled out from PR ( https://github.com/zarr-developers/numcodecs/pull/121 )

When running the `check_backwards_compatibility` test, make sure not to call `buffer_tobytes` on `object` arrays from fixture data. Casting these to bytes doesn't really make sense as it will return representation of pointers in the underlying buffer. Not only are the pointers things we do not want to be comparing, but it is also internal spec to NumPy and Python that really isn't reliable either. So make sure to pass through the `object` arrays as is.

[Description of PR]

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
