### PR TITLE
Configure flake8's line length as 100

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     py27,py35,py36: pytest -v --cov=numcodecs numcodecs
     py37: pytest -v --cov=numcodecs --doctest-modules --doctest-glob=*.pyx numcodecs
     coverage report -m
-    py37: flake8 --max-line-length=100 numcodecs
+    py37: flake8 numcodecs
     pip freeze
 deps =
     py27: backports.lzma
@@ -31,3 +31,6 @@ deps =
     -rrequirements_rtfd.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+
+[flake8]
+max-line-length = 100


### PR DESCRIPTION
This allows users to run `flake8 numcodecs` and pick up the desired configuration by default.

[Description of PR]

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
