### PR TITLE
Add link about Python 2 GZip workaround

### DIFF
--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -29,6 +29,7 @@ class GZip(Codec):
         buf = ensure_contiguous_ndarray(buf)
         if PY2:  # pragma: py3 no cover
             # view as u1 needed on PY2
+            # ref: https://github.com/zarr-developers/numcodecs/pull/128#discussion_r236786466
             buf = buf.view('u1')
 
         # do compression


### PR DESCRIPTION
Lest we or others wonder what this workaround is doing. Link back to the PR comment for details.

TL;DR - GZip on Python 2 (and Python pre-3.5) determines the number of bytes included via `len`, which is needed for the GZip footer. This will be incorrect if the data is not flattened and using a single byte type. Hence we cast to `uint8` here to satisfy this constraint. On Python 3.5+ this is not needed as it casts the data to a `memoryview` and accesses the `nbytes` attribute to determine this.

ref: https://github.com/zarr-developers/numcodecs/pull/128#discussion_r236786466

[Description of PR]

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
