### PR TITLE
Cutdown copies with BytesIO

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -30,7 +30,7 @@ Release notes
 * Add Python 3.7 (by :user:`John Kirkham <jakirkham>`; :issue:`92`).
 
 * Add codec :class:`numcodecs.gzip.GZip` to replace ``gzip`` alias for ``zlib``,
-  which was incorrect (by :user:`Jan Funke <funkey>`; :issue:`87`).
+  which was incorrect (by :user:`Jan Funke <funkey>`; :issue:`87`; and :user:`John Kirkham <jakirkham>`, :issue:`134`).
 
 * Corrects handling of ``NaT`` in ``datetime64`` and ``timedelta64`` in various
   compressors (by :user:`John Kirkham <jakirkham>`; :issue:`127`, :issue:`131`).

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -59,7 +59,7 @@ class GZip(Codec):
                 out = ensure_contiguous_ndarray(out)
                 nbytes = decompressor.readinto(out)
                 nbytes += len(decompressor.read())
-                if nbytes != out.nbytes:
+                if nbytes > out.nbytes:
                     raise ValueError("`out` unable to fit %i bytes" % nbytes)
             else:
                 out = ensure_ndarray(decompressor.read())

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -57,7 +57,7 @@ class GZip(Codec):
         with _gzip.GzipFile(fileobj=buf, mode='rb') as decompressor:
             if out is not None:
                 decompressed = ensure_contiguous_ndarray(out)
-                decompressor.readinto(decompressed.view('u1'))
+                decompressor.readinto(decompressed)
             else:
                 decompressed = ensure_ndarray(decompressor.read())
 

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -56,8 +56,8 @@ class GZip(Codec):
         buf = io.BytesIO(buf)
         with _gzip.GzipFile(fileobj=buf, mode='rb') as decompressor:
             if out is not None:
-                out = ensure_contiguous_ndarray(out)
-                decompressor.readinto(out)
+                out_view = ensure_contiguous_ndarray(out)
+                decompressor.readinto(out_view)
                 if decompressor.read(1) != b'':
                     raise ValueError("Unable to fit data into `out`")
             else:

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -38,9 +38,13 @@ class GZip(Codec):
                             mode='wb',
                             compresslevel=self.level) as compressor:
             compressor.write(buf)
-        compressed = compressed.getvalue()
 
-        return compressed
+        try:
+            compressed = compressed.getbuffer()
+        except AttributeError:  # pragma: py3 no cover
+            compressed = memoryview(compressed.getvalue())
+
+        return np.array(compressed, copy=False)
 
     # noinspection PyMethodMayBeStatic
     def decode(self, buf, out=None):

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -57,10 +57,9 @@ class GZip(Codec):
         with _gzip.GzipFile(fileobj=buf, mode='rb') as decompressor:
             if out is not None:
                 out = ensure_contiguous_ndarray(out)
-                nbytes = decompressor.readinto(out)
-                nbytes += len(decompressor.read())
-                if nbytes > out.nbytes:
-                    raise ValueError("`out` unable to fit %i bytes" % nbytes)
+                decompressor.readinto(out)
+                if decompressor.read(1) != b'':
+                    raise ValueError("Unable to write data into `out`")
             else:
                 out = ensure_ndarray(decompressor.read())
 

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -56,15 +56,15 @@ class GZip(Codec):
         buf = io.BytesIO(buf)
         with _gzip.GzipFile(fileobj=buf, mode='rb') as decompressor:
             if out is not None:
-                decompressed = ensure_contiguous_ndarray(out)
-                nbytes = decompressor.readinto(decompressed)
+                out = ensure_contiguous_ndarray(out)
+                nbytes = decompressor.readinto(out)
                 nbytes += len(decompressor.read())
-                if nbytes != decompressed.nbytes:
+                if nbytes != out.nbytes:
                     raise ValueError("`out` unable to fit %i bytes" % nbytes)
             else:
-                decompressed = ensure_ndarray(decompressor.read())
+                out = ensure_ndarray(decompressor.read())
 
         # handle destination - Python standard library zlib module does not
         # support direct decompression into buffer, so we have to copy into
         # out if given
-        return decompressed
+        return out

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -57,7 +57,10 @@ class GZip(Codec):
         with _gzip.GzipFile(fileobj=buf, mode='rb') as decompressor:
             if out is not None:
                 decompressed = ensure_contiguous_ndarray(out)
-                decompressor.readinto(decompressed)
+                nbytes = decompressor.readinto(decompressed)
+                nbytes += len(decompressor.read())
+                if nbytes != decompressed.nbytes:
+                    raise ValueError("`out` unable to fit %i bytes" % nbytes)
             else:
                 decompressed = ensure_ndarray(decompressor.read())
 

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -51,8 +51,12 @@ class GZip(Codec):
 
         # normalise inputs
         if PY2:  # pragma: py3 no cover
+            # On Python 2, BytesIO always copies.
+            # Merely ensure the data supports the (new) buffer protocol.
             buf = ensure_contiguous_ndarray(buf)
         else:  # pragma: py2 no cover
+            # BytesIO only copies if the data is not of `bytes` type.
+            # This allows `bytes` objects to pass through without copying.
             buf = ensure_bytes(buf)
 
         # do decompression

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -59,7 +59,7 @@ class GZip(Codec):
                 out = ensure_contiguous_ndarray(out)
                 decompressor.readinto(out)
                 if decompressor.read(1) != b'':
-                    raise ValueError("Unable to write data into `out`")
+                    raise ValueError("Unable to fit data into `out`")
             else:
                 out = ensure_ndarray(decompressor.read())
 

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -5,7 +5,7 @@ import io
 
 
 from .abc import Codec
-from .compat import ensure_ndarray, ensure_contiguous_ndarray, PY2
+from .compat import ensure_bytes, ensure_ndarray, ensure_contiguous_ndarray, PY2
 
 
 class GZip(Codec):
@@ -50,7 +50,10 @@ class GZip(Codec):
     def decode(self, buf, out=None):
 
         # normalise inputs
-        buf = ensure_contiguous_ndarray(buf)
+        if PY2:  # pragma: py3 no cover
+            buf = ensure_contiguous_ndarray(buf)
+        else:  # pragma: py2 no cover
+            buf = ensure_bytes(buf)
 
         # do decompression
         buf = io.BytesIO(buf)

--- a/numcodecs/tests/test_gzip.py
+++ b/numcodecs/tests/test_gzip.py
@@ -96,7 +96,6 @@ def test_err_encode_non_contiguous():
 
 
 def test_err_out_too_small():
-    # non-contiguous memory
     arr = np.arange(10, dtype='i4')
     out = np.empty_like(arr)[:-1]
     for codec in codecs:
@@ -105,7 +104,6 @@ def test_err_out_too_small():
 
 
 def test_out_too_large():
-    # non-contiguous memory
     out = np.empty((10,), dtype='i4')
     arr = out[:-1]
     arr[:] = 5

--- a/numcodecs/tests/test_gzip.py
+++ b/numcodecs/tests/test_gzip.py
@@ -93,3 +93,22 @@ def test_err_encode_non_contiguous():
     for codec in codecs:
         with pytest.raises(ValueError):
             codec.encode(arr)
+
+
+def test_err_out_too_small():
+    # non-contiguous memory
+    arr = np.arange(10, dtype='i4')
+    out = np.empty_like(arr)[:-1]
+    for codec in codecs:
+        with pytest.raises(ValueError):
+            codec.decode(codec.encode(arr), out)
+
+
+def test_err_out_too_large():
+    # non-contiguous memory
+    out = np.empty((10,), dtype='i4')
+    arr = out[:-1]
+    arr[:] = 5
+    for codec in codecs:
+        with pytest.raises(ValueError):
+            codec.decode(codec.encode(arr), out)

--- a/numcodecs/tests/test_gzip.py
+++ b/numcodecs/tests/test_gzip.py
@@ -104,11 +104,10 @@ def test_err_out_too_small():
             codec.decode(codec.encode(arr), out)
 
 
-def test_err_out_too_large():
+def test_out_too_large():
     # non-contiguous memory
     out = np.empty((10,), dtype='i4')
     arr = out[:-1]
     arr[:] = 5
     for codec in codecs:
-        with pytest.raises(ValueError):
-            codec.decode(codec.encode(arr), out)
+        codec.decode(codec.encode(arr), out)


### PR DESCRIPTION
This is currently an exploratory PR, which tries to use `BytesIO` to avoid some copies.

TODO:
* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [x] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
