### PR TITLE
Drop outdated comment in `GZip`'s `decode`

### DIFF
--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -70,7 +70,4 @@ class GZip(Codec):
             else:
                 out = ensure_ndarray(decompressor.read())
 
-        # handle destination - Python standard library zlib module does not
-        # support direct decompression into buffer, so we have to copy into
-        # out if given
         return out


### PR DESCRIPTION
This comment doesn't really make any sense given the code below it. Likely it is leftover after some code changes that have made it irrelevant.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
