### PR TITLE
Handle (new) buffer protocol conforming types in ``Pickle.decode``

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,6 +1,15 @@
 Release notes
 =============
 
+.. _release_0.6.2:
+
+0.6.2
+-----
+
+* Handle (new) buffer protocol conforming types in ``Pickle.decode``.
+  (by :user:`John Kirkham <jakirkham>`, :issue:`143`).
+
+
 .. _release_0.6.1:
 
 0.6.1

--- a/numcodecs/pickles.py
+++ b/numcodecs/pickles.py
@@ -48,9 +48,9 @@ class Pickle(Codec):
         return pickle.dumps(buf, protocol=self.protocol)
 
     def decode(self, buf, out=None):
-        if PY2:
+        if PY2:  # pragma: py3 no cover
             buf = ensure_bytes(buf)
-        else:
+        else:  # pragma: py2 no cover
             buf = ensure_contiguous_ndarray(buf)
 
         dec = pickle.loads(buf)

--- a/numcodecs/pickles.py
+++ b/numcodecs/pickles.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 from .abc import Codec
-from .compat import PY2, ensure_bytes
+from .compat import PY2, ensure_bytes, ensure_contiguous_ndarray
 
 
 if PY2:  # pragma: py3 no cover
@@ -50,6 +50,8 @@ class Pickle(Codec):
     def decode(self, buf, out=None):
         if PY2:
             buf = ensure_bytes(buf)
+        else:
+            buf = ensure_contiguous_ndarray(buf)
 
         dec = pickle.loads(buf)
         if out is not None:

--- a/numcodecs/pickles.py
+++ b/numcodecs/pickles.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 from .abc import Codec
-from .compat import PY2
+from .compat import PY2, ensure_bytes
 
 
 if PY2:  # pragma: py3 no cover
@@ -48,6 +48,9 @@ class Pickle(Codec):
         return pickle.dumps(buf, protocol=self.protocol)
 
     def decode(self, buf, out=None):
+        if PY2:
+            buf = ensure_bytes(buf)
+
         dec = pickle.loads(buf)
         if out is not None:
             np.copyto(out, dec)

--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -147,6 +147,10 @@ def check_encode_decode_array(arr, codec):
     codec.decode(enc, out=out)
     assert_array_items_equal(arr, out)
 
+    enc = codec.encode(arr)
+    dec = codec.decode(ensure_ndarray(enc))
+    assert_array_items_equal(arr, dec)
+
 
 def check_config(codec):
     config = codec.get_config()

--- a/numcodecs/tests/test_pickles.py
+++ b/numcodecs/tests/test_pickles.py
@@ -6,10 +6,11 @@ import itertools
 import numpy as np
 
 
-from numcodecs.compat import PY2
+from numcodecs.compat import PY2, ensure_ndarray
 from numcodecs.pickles import Pickle
-from numcodecs.tests.common import (check_config, check_repr, check_encode_decode_array,
-                                    check_backwards_compatibility, greetings)
+from numcodecs.tests.common import (assert_array_items_equal, check_config, check_repr,
+                                    check_encode_decode_array, check_backwards_compatibility,
+                                    greetings)
 
 
 codecs = [
@@ -41,6 +42,12 @@ arrays = [
 def test_encode_decode():
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode_array(arr, codec)
+
+
+def test_decode_ndarray():
+    for arr, codec in itertools.product(arrays, codecs):
+        buf = ensure_ndarray(codec.encode(arr))
+        assert_array_items_equal(arr, codec.decode(buf))
 
 
 def test_config():

--- a/numcodecs/tests/test_pickles.py
+++ b/numcodecs/tests/test_pickles.py
@@ -6,11 +6,10 @@ import itertools
 import numpy as np
 
 
-from numcodecs.compat import PY2, ensure_ndarray
+from numcodecs.compat import PY2
 from numcodecs.pickles import Pickle
-from numcodecs.tests.common import (assert_array_items_equal, check_config, check_repr,
-                                    check_encode_decode_array, check_backwards_compatibility,
-                                    greetings)
+from numcodecs.tests.common import (check_config, check_repr, check_encode_decode_array,
+                                    check_backwards_compatibility, greetings)
 
 
 codecs = [
@@ -42,12 +41,6 @@ arrays = [
 def test_encode_decode():
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode_array(arr, codec)
-
-
-def test_decode_ndarray():
-    for arr, codec in itertools.product(arrays, codecs):
-        buf = ensure_ndarray(codec.encode(arr))
-        assert_array_items_equal(arr, codec.decode(buf))
 
 
 def test_config():


### PR DESCRIPTION
Python 3's `pickle.loads` is able to handle anything that conforms to the (new) buffer protocol as long as it is C-contiguous. We go ahead and enforce this on all inputs; raising if that is not possible. On Python 2 `cPickle.loads` is not as flexible as it requires a `bytes` object explicitly. This enforces that case as well.

TODO:
* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in docs/release.rst
* [x] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
