### PR TITLE
Upgrade c-blosc to v1.15.0

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -25,7 +25,7 @@ Release notes
   By :user:`John Kirkham <jakirkham>`, :issue:`155`.
 
 * The bundled c-blosc sources have been upgraded to version 1.15.0. By
-  :user:`Alistair Miles <alimanfoo>`, :issue:`142`, :issue:`145`.
+  :user:`Alistair Miles <alimanfoo>` and :user:`John Kirkham <jakirkham>`, :issue:`142`, :issue:`145`.
 
 .. _release_0.6.1:
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -24,6 +24,8 @@ Release notes
 * Revert ndarray coercion of encode returned data.
   By :user:`John Kirkham <jakirkham>`, :issue:`155`.
 
+* The bundled c-blosc sources have been upgraded to version 1.15.0. By
+  :user:`Alistair Miles <alimanfoo>`, :issue:`142`, :issue:`145`.
 
 .. _release_0.6.1:
 


### PR DESCRIPTION
Upgrade the c-blosc submodule to version 1.15.0. Resolves #142.

TODO:
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [x] Changes documented in docs/release.rst
* [x] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
