### PR TITLE
 Use (new) buffer protocol in `*MsgPack`'s `decode`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -7,10 +7,13 @@ Release notes
 -----
 
 * Handle (new) buffer protocol conforming types in ``Pickle.decode``.
-  (by :user:`John Kirkham <jakirkham>`, :issue:`143`).
+  By :user:`John Kirkham <jakirkham>`, :issue:`143`.
 
 * Fix other ``VLen*`` encode() methods to return numpy arrays as well.
   By :user:`John Kirkham <jakirkham>`, :issue:`144`.
+  
+* Use (new) buffer protocol in ``MsgPack`` codec `decode()` method.
+  By :user:`John Kirkham <jakirkham>`, :issue:`148`.
 
 
 .. _release_0.6.1:

--- a/numcodecs/msgpacks.py
+++ b/numcodecs/msgpacks.py
@@ -7,7 +7,7 @@ import msgpack
 
 
 from .abc import Codec
-from .compat import ensure_bytes
+from .compat import ensure_contiguous_ndarray
 
 
 class MsgPack(Codec):
@@ -64,7 +64,7 @@ class MsgPack(Codec):
                              use_single_float=self.use_single_float)
 
     def decode(self, buf, out=None):
-        buf = ensure_bytes(buf)
+        buf = ensure_contiguous_ndarray(buf)
         items = msgpack.unpackb(buf, raw=self.raw)
         dec = np.empty(items[-1], dtype=items[-2])
         dec[:] = items[:-2]
@@ -111,7 +111,7 @@ class LegacyMsgPack(Codec):
         return msgpack.packb(items, encoding=self.encoding)
 
     def decode(self, buf, out=None):
-        buf = ensure_bytes(buf)
+        buf = ensure_contiguous_ndarray(buf)
         items = msgpack.unpackb(buf, encoding=self.encoding)
         dec = np.array(items[:-1], dtype=items[-1])
         if out is not None:


### PR DESCRIPTION
The `msgpack` implementation can leverage the (new) buffer protocol with input data. To leverage this, `msgpack` requires that the data is C-contiguous. To take advantage of this and avoid a copy with our data, use `ensure_contiguous_ndarray` to take view onto the `buf` provided and flatten it. Then pass the resulting `ndarray` to `msgpack.unpackb`, which in turn will use the buffer protocol to perform the unpacking without copying.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
