### PR TITLE
Use (new) buffer protocol in `Pickle.decode` on Python 2

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -7,7 +7,7 @@ Release notes
 -----
 
 * Handle (new) buffer protocol conforming types in ``Pickle.decode``.
-  By :user:`John Kirkham <jakirkham>`, :issue:`143`.
+  By :user:`John Kirkham <jakirkham>`, :issue:`143`, :issue:`150`.
 
 * Fix other ``VLen*`` encode() methods to return numpy arrays as well.
   By :user:`John Kirkham <jakirkham>`, :issue:`144`.

--- a/numcodecs/pickles.py
+++ b/numcodecs/pickles.py
@@ -6,11 +6,12 @@ import numpy as np
 
 
 from .abc import Codec
-from .compat import PY2, ensure_bytes, ensure_contiguous_ndarray
+from .compat import PY2, ensure_contiguous_ndarray
 
 
 if PY2:  # pragma: py3 no cover
     import cPickle as pickle
+    from cStringIO import StringIO
 else:  # pragma: py2 no cover
     import pickle
 
@@ -48,12 +49,13 @@ class Pickle(Codec):
         return pickle.dumps(buf, protocol=self.protocol)
 
     def decode(self, buf, out=None):
-        if PY2:  # pragma: py3 no cover
-            buf = ensure_bytes(buf)
-        else:  # pragma: py2 no cover
-            buf = ensure_contiguous_ndarray(buf)
+        buf = ensure_contiguous_ndarray(buf)
 
-        dec = pickle.loads(buf)
+        if PY2:  # pragma: py3 no cover
+            dec = pickle.load(StringIO(buf))
+        else:  # pragma: py2 no cover
+            dec = pickle.loads(buf)
+
         if out is not None:
             np.copyto(out, dec)
             return out


### PR DESCRIPTION
On Python 3, `pickle.loads` is able to take anything that conforms to the (new) buffer protocol. So there has been no issue giving it an `ndarray` to work with. Unfortunately, on Python 2, `pickle.loads` requires a `bytes` object specifically and is not able to take any type implementing the (new) buffer protocol. So we have been going ahead and coercing everything to `bytes` on Python 2.

However it turns out that `cStringIO`'s `StringIO` on Python 2 does support the buffer protocol. Thus a `StringIO` object can be created on Python 2 without copying the data. While this still cannot be used with `pickle.loads`, it can be used with `pickle.load`, which special cases reading from `StringIO` leveraging the read function, which amounts to sharing a pointer between `StringIO` and `pickle.loads`. Thus achieving a no copying unpickler for Python 2.

ref: http://www.hydrogen18.com/blog/unpickling-buffers.html

ref: https://github.com/python/cpython/blob/2.7/Modules/cStringIO.c#L716
ref: https://github.com/python/cpython/blob/2.7/Modules/cStringIO.c#L681
ref: https://github.com/python/cpython/blob/2.7/Modules/cPickle.c#L614
ref: https://github.com/python/cpython/blob/2.7/Modules/cStringIO.c#L160

TODO:
* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [x] Docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in docs/release.rst
* [x] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
