### PR TITLE
Use (new) buffer protocol in `*JSON`'s `decode`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,6 +15,9 @@ Release notes
 * Use (new) buffer protocol in ``MsgPack`` codec `decode()` method.
   By :user:`John Kirkham <jakirkham>`, :issue:`148`.
 
+* Use (new) buffer protocol in ``JSON`` codec `decode()` method.
+  By :user:`John Kirkham <jakirkham>`, :issue:`151`.
+
 
 .. _release_0.6.1:
 

--- a/numcodecs/json.py
+++ b/numcodecs/json.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
+import codecs
 import json as _json
 import textwrap
 
@@ -8,7 +9,7 @@ import numpy as np
 
 
 from .abc import Codec
-from .compat import ensure_bytes
+from .compat import ensure_contiguous_ndarray
 
 
 class JSON(Codec):
@@ -63,8 +64,8 @@ class JSON(Codec):
         return self._encoder.encode(items).encode(self._text_encoding)
 
     def decode(self, buf, out=None):
-        buf = ensure_bytes(buf)
-        items = self._decoder.decode(buf.decode(self._text_encoding))
+        buf = ensure_contiguous_ndarray(buf)
+        items = self._decoder.decode(codecs.decode(buf, self._text_encoding))
         dec = np.empty(items[-1], dtype=items[-2])
         dec[:] = items[:-2]
         if out is not None:
@@ -125,8 +126,8 @@ class LegacyJSON(JSON):
         return self._encoder.encode(items).encode(self._text_encoding)
 
     def decode(self, buf, out=None):
-        buf = ensure_bytes(buf)
-        items = self._decoder.decode(buf.decode(self._text_encoding))
+        buf = ensure_contiguous_ndarray(buf)
+        items = self._decoder.decode(codecs.decode(buf, self._text_encoding))
         dec = np.array(items[:-1], dtype=items[-1])
         if out is not None:
             np.copyto(out, dec)


### PR DESCRIPTION
In Python 2/3, `codecs.decode` performs decoding analogous to `bytes.decode` except that it is not limited to `bytes`. In fact, it can take anything that supports the (new) buffer protocol. Thus we can avoid copying the data and instead only take an `ndarray` view onto it before passing the buffer to `codecs.decode`. Should improve performance a bit by avoiding this copy.

TODO:
* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [x] Docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in docs/release.rst
* [x] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
