### PR TITLE
Use buffer `StringIO` in `GZip.decode` on Python 2

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,6 +15,9 @@ Release notes
 * Use (new) buffer protocol in ``MsgPack`` codec `decode()` method.
   By :user:`John Kirkham <jakirkham>`, :issue:`148`.
 
+* Avoid copying into data in ``GZip``'s `decode()` method on Python 2.
+  By :user:`John Kirkham <jakirkham>`, :issue:`152`.
+
 
 .. _release_0.6.1:
 

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -8,6 +8,10 @@ from .abc import Codec
 from .compat import ensure_bytes, ensure_ndarray, ensure_contiguous_ndarray, PY2
 
 
+if PY2:  # pragma: py3 no cover
+    from cStringIO import StringIO
+
+
 class GZip(Codec):
     """Codec providing gzip compression using zlib via the Python standard library.
 
@@ -51,16 +55,14 @@ class GZip(Codec):
 
         # normalise inputs
         if PY2:  # pragma: py3 no cover
-            # On Python 2, BytesIO always copies.
-            # Merely ensure the data supports the (new) buffer protocol.
-            buf = ensure_contiguous_ndarray(buf)
+            # On Python 2, StringIO always uses the buffer protocol.
+            buf = StringIO(ensure_contiguous_ndarray(buf))
         else:  # pragma: py2 no cover
             # BytesIO only copies if the data is not of `bytes` type.
             # This allows `bytes` objects to pass through without copying.
-            buf = ensure_bytes(buf)
+            buf = io.BytesIO(ensure_bytes(buf))
 
         # do decompression
-        buf = io.BytesIO(buf)
         with _gzip.GzipFile(fileobj=buf, mode='rb') as decompressor:
             if out is not None:
                 out_view = ensure_contiguous_ndarray(out)


### PR DESCRIPTION
Extends the strategy from PR ( https://github.com/zarr-developers/numcodecs/pull/150 ) to `GZip`.

In `GZip`'s `decode` method, we knew that `BytesIO` was always copying the data. So we merely ensured the data was in a form that made it easy to copy (i.e. a contiguous buffer). However we have since learned we can do better as the Python 2 implementation of `StringIO` merely takes the buffer without copying it. So use `StringIO` on Python 2 to avoid a copy here. As this support doesn't extend to Python 3, continue using `BytesIO` in that case. Should avoid copies on Python 2 in the general case when using `GZip`'s `decode`; thus, improving performance there.

ref: http://www.hydrogen18.com/blog/unpickling-buffers.html

ref: https://github.com/python/cpython/blob/2.7/Modules/cStringIO.c#L716
ref: https://github.com/python/cpython/blob/2.7/Modules/cStringIO.c#L681
ref: https://github.com/python/cpython/blob/2.7/Modules/cStringIO.c#L160

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
