### PR TITLE
WIP: Use buffer protocol with `GZip.decode` on Python 2/3

### DIFF
--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -5,11 +5,7 @@ import io
 
 
 from .abc import Codec
-from .compat import ensure_bytes, ensure_contiguous_ndarray, PY2
-
-
-if PY2:  # pragma: py3 no cover
-    from cStringIO import StringIO
+from .compat import ensure_contiguous_ndarray, PY2, MemoryViewIO
 
 
 class GZip(Codec):
@@ -50,13 +46,7 @@ class GZip(Codec):
     def decode(self, buf, out=None):
 
         # normalise inputs
-        if PY2:  # pragma: py3 no cover
-            # On Python 2, StringIO always uses the buffer protocol.
-            buf = StringIO(ensure_contiguous_ndarray(buf))
-        else:  # pragma: py2 no cover
-            # BytesIO only copies if the data is not of `bytes` type.
-            # This allows `bytes` objects to pass through without copying.
-            buf = io.BytesIO(ensure_bytes(buf))
+        buf = MemoryViewIO(buf)
 
         # do decompression
         with _gzip.GzipFile(fileobj=buf, mode='rb') as decompressor:

--- a/numcodecs/gzip.py
+++ b/numcodecs/gzip.py
@@ -8,6 +8,10 @@ from .abc import Codec
 from .compat import ensure_contiguous_ndarray, PY2, MemoryViewIO
 
 
+if PY2:  # pragma: py3 no cover
+    from cStringIO import StringIO
+
+
 class GZip(Codec):
     """Codec providing gzip compression using zlib via the Python standard library.
 
@@ -46,7 +50,13 @@ class GZip(Codec):
     def decode(self, buf, out=None):
 
         # normalise inputs
-        buf = MemoryViewIO(buf)
+        buf = ensure_contiguous_ndarray(buf)
+        if PY2:  # pragma: py3 no cover
+            # On Python 2, StringIO always uses the buffer protocol.
+            buf = StringIO(buf)
+        else:  # pragma: py2 no cover
+            # MemoryViewIO always uses the buffer protocol.
+            buf = MemoryViewIO(buf)
 
         # do decompression
         with _gzip.GzipFile(fileobj=buf, mode='rb') as decompressor:


### PR DESCRIPTION
This is not complete. Am merely putting it up for reference and possibly discussion, but it is not pressing ATM.

Basically creates a custom file object, `MemoryViewIO`, that takes a (new) buffer protocol conforming item and allows users to work with it like an ordinary file object (e.g. `BytesIO`). However it avoids copying the underlying buffer and instead merely views it, which differs from `BytesIO`. This is used with `GzipFile` as the `fileobj` parameter to allow decompression to occur without an additional copy of the full data.

Though there are still some wrinkles to work out. Namely this doesn't work on Python 2 due to some unusual bugs, which are causing test failures. Will probably take some time to get to the bottom of them. The latest commit restricts `MemoryViewIO` usage to Python 3 where it seems to work well. Also test coverage will need to be improved too.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
