### PR TITLE
Drop win32 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,27 +12,15 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7"
-
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7"
       DISTUTILS_USE_SDK: "1"
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5"
-
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5"
 
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6"
-
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6"
-
-    - PYTHON: "C:\\Python37"
-      PYTHON_VERSION: "3.7"
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,6 +1,10 @@
 Release notes
 =============
 
+
+* Drop support for 32-bit Windows. By :user:`Alistair Miles <alimanfoo>`, :issue:`97`, :issue:`156`.
+
+
 .. _release_0.6.2:
 
 0.6.2


### PR DESCRIPTION
Removes 32-bit appveyor builds. Resolves #97.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
