### PR TITLE
Raise on `object` arrays in `ensure_bytes`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -4,6 +4,9 @@ Release notes
 
 * Drop support for 32-bit Windows. By :user:`Alistair Miles <alimanfoo>`, :issue:`97`, :issue:`156`.
 
+* Raise a ``TypeError`` if an ``object`` array is passed to ``ensure_bytes``.
+  By :user:`John Kirkham <jakirkham>`, :issue:`162`.
+
 
 .. _release_0.6.2:
 

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -152,6 +152,11 @@ def ensure_bytes(buf):
         # go via numpy, for convenience
         arr = ensure_ndarray(buf)
 
+        # check for object arrays, these are just memory pointers,
+        # actual memory holding item data is scattered elsewhere
+        if arr.dtype == object:
+            raise TypeError('object arrays are not supported')
+
         # create bytes
         buf = arr.tobytes(order='A')
 

--- a/numcodecs/tests/test_compat.py
+++ b/numcodecs/tests/test_compat.py
@@ -51,6 +51,15 @@ def test_ensure_contiguous_ndarray_shares_memory():
             assert np.shares_memory(a, memoryview(buf))
 
 
+def test_ensure_bytes_invalid_inputs():
+
+    # object array not allowed
+    a = np.array([u'Xin chào thế giới'], dtype=object)
+    for e in [a, memoryview(a)]:
+        with pytest.raises(TypeError):
+            ensure_bytes(e)
+
+
 def test_ensure_contiguous_ndarray_invalid_inputs():
 
     # object array not allowed


### PR DESCRIPTION
Check for the input to be an `object` array in `ensure_bytes` and raise a `TypeError` if it is. Also include a test to check that this case is handled properly by `ensure_bytes`.

TODO:
* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [x] Docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in docs/release.rst
* [x] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
