### PR TITLE
Simplify datetime/timedelta check

### DIFF
--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -121,7 +121,7 @@ def ensure_contiguous_ndarray(buf, max_buffer_size=None):
     arr = ensure_ndarray(buf)
 
     # check for datetime or timedelta ndarray, the buffer interface doesn't support those
-    if isinstance(buf, np.ndarray) and buf.dtype.kind in 'Mm':
+    if arr.dtype.kind in 'Mm':
         arr = arr.view(np.int64)
 
     # check for object arrays, these are just memory pointers, actual memory holding


### PR DESCRIPTION
As we already know that `arr` must be an array, simply check the array's type to see if it is datetime/timedelta. Thus this avoids the check of whether `buf` is an array.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
