### PR TITLE
Handle datetime/timedelta case after object case

### DIFF
--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -120,14 +120,14 @@ def ensure_contiguous_ndarray(buf, max_buffer_size=None):
     # ensure input is a numpy array
     arr = ensure_ndarray(buf)
 
-    # check for datetime or timedelta ndarray, the buffer interface doesn't support those
-    if arr.dtype.kind in 'Mm':
-        arr = arr.view(np.int64)
-
     # check for object arrays, these are just memory pointers, actual memory holding
     # item data is scattered elsewhere
     if arr.dtype == object:
         raise TypeError('object arrays are not supported')
+
+    # check for datetime or timedelta ndarray, the buffer interface doesn't support those
+    if arr.dtype.kind in 'Mm':
+        arr = arr.view(np.int64)
 
     # check memory is contiguous, if so flatten
     if arr.flags.c_contiguous or arr.flags.f_contiguous:


### PR DESCRIPTION
As the object check and datetime/timedelta check are exclusive and the object check follows by raising an exception, go ahead and swap the order of these two checks to have the object check go first. That way, we are not spending time running the object check after we have already determined it is datetime or timedelta and casted it to a non-object type array. Instead we merely have verified it is a non-object array if we got to the datetime/timedelta check, which makes it being datetime or timedelta a possibility, but not a certainty.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
