### PR TITLE
Update Cython release note to 0.29.5

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -7,8 +7,8 @@ Release notes
 * Raise a ``TypeError`` if an ``object`` array is passed to ``ensure_bytes``.
   By :user:`John Kirkham <jakirkham>`, :issue:`162`.
 
-* Update Cython to 0.29.3.
-  By :user:`John Kirkham <jakirkham>`, :issue:`165`.
+* Update Cython to 0.29.5.
+  By :user:`John Kirkham <jakirkham>`, :issue:`168`.
 
 
 .. _release_0.6.2:


### PR DESCRIPTION


TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
