### PR TITLE
Update URL metadata for PyPI.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -350,7 +350,7 @@ def run_setup(with_extensions):
         author_email='alimanfoo@googlemail.com',
         maintainer='Alistair Miles',
         maintainer_email='alimanfoo@googlemail.com',
-        url='https://github.com/alimanfoo/numcodecs',
+        url='https://github.com/zarr-developers/numcodecs',
         license='MIT',
     )
 


### PR DESCRIPTION
As in title.

TODO:
* [N/A] Unit tests and/or doctests in docstrings
* [N/A] ``tox -e py37`` passes locally
* [N/A] ``tox -e py27`` passes locally
* [N/A] Docstrings and API docs for any new/modified user-facing classes and functions
* [N/A] Changes documented in docs/release.rst
* [N/A] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
