### PR TITLE
Use unittest.mock on Python 3.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,9 +21,9 @@ import os
 PY2 = sys.version_info[0] == 2
 
 
-if PY2:
+if PY2:  # pragma: py3 no cover
     from mock import Mock as MagicMock
-else:
+else:    # pragma: py2 no cover
     from unittest.mock import Mock as MagicMock
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,10 +16,15 @@
 
 import sys
 import os
-from mock import Mock as MagicMock
 
 
 PY2 = sys.version_info[0] == 2
+
+
+if PY2:
+    from mock import Mock as MagicMock
+else:
+    from unittest.mock import Mock as MagicMock
 
 
 class Mock(MagicMock):


### PR DESCRIPTION
As in title; reduces the dependencies by one.

TODO:
* [N/A] Unit tests and/or doctests in docstrings
* [N/A] ``tox -e py37`` passes locally
* [N/A] ``tox -e py27`` passes locally
* [N/A] Docstrings and API docs for any new/modified user-facing classes and functions
* [N/A] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
