### PR TITLE
Enable pytest rewriting in test helper functions.

### DIFF
--- a/numcodecs/tests/__init__.py
+++ b/numcodecs/tests/__init__.py
@@ -1,2 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
+
+import pytest
+
+pytest.register_assert_rewrite('numcodecs.tests.common')


### PR DESCRIPTION
If you call a helper function from `numcodecs.tests.common` and it fails, pytest will show a generic assertion message. But with assertion rewriting enabled, it will shows its full verbose output (i.e., expanding left and write values, showing local variables, etc.)

TODO:
* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [N/A] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
