### PR TITLE
Fix test failures on big-endian systems

### DIFF
--- a/numcodecs/tests/test_astype.py
+++ b/numcodecs/tests/test_astype.py
@@ -63,7 +63,7 @@ def test_backwards_compatibility():
     # integers
     arrs = [
         np.arange(1000, dtype='<i4'),
-        np.random.randint(0, 200, size=1000, dtype='<i4').reshape(100, 10, order='F'),
+        np.random.randint(0, 200, size=1000, dtype='i4').astype('<i4').reshape(100, 10, order='F'),
     ]
     codec = AsType(encode_dtype='<i2', decode_dtype='<i4')
     check_backwards_compatibility(AsType.codec_id, arrs, [codec], prefix='i')

--- a/numcodecs/tests/test_delta.py
+++ b/numcodecs/tests/test_delta.py
@@ -16,10 +16,10 @@ from numcodecs.tests.common import (check_encode_decode, check_config, check_rep
 # mix of shapes: 1D, 2D, 3D
 # mix of orders: C, F
 arrays = [
-    np.arange(1000, dtype='i4'),
-    np.linspace(1000, 1001, 1000, dtype='f4').reshape(100, 10),
-    np.random.normal(loc=1000, scale=1, size=(10, 10, 10)).astype('f8'),
-    np.random.randint(0, 200, size=1000, dtype='u2').reshape(100, 10, order='F'),
+    np.arange(1000, dtype='<i4'),
+    np.linspace(1000, 1001, 1000, dtype='<f4').reshape(100, 10),
+    np.random.normal(loc=1000, scale=1, size=(10, 10, 10)).astype('<f8'),
+    np.random.randint(0, 200, size=1000, dtype='u2').astype('<u2').reshape(100, 10, order='F'),
 ]
 
 

--- a/numcodecs/tests/test_fixedscaleoffset.py
+++ b/numcodecs/tests/test_fixedscaleoffset.py
@@ -14,20 +14,20 @@ from numcodecs.tests.common import (check_encode_decode, check_config, check_rep
 
 
 arrays = [
-    np.linspace(1000, 1001, 1000, dtype='f8'),
-    np.random.normal(loc=1000, scale=1, size=1000).astype('f8'),
-    np.linspace(1000, 1001, 1000, dtype='f8').reshape(100, 10),
-    np.linspace(1000, 1001, 1000, dtype='f8').reshape(100, 10, order='F'),
-    np.linspace(1000, 1001, 1000, dtype='f8').reshape(10, 10, 10),
+    np.linspace(1000, 1001, 1000, dtype='<f8'),
+    np.random.normal(loc=1000, scale=1, size=1000).astype('<f8'),
+    np.linspace(1000, 1001, 1000, dtype='<f8').reshape(100, 10),
+    np.linspace(1000, 1001, 1000, dtype='<f8').reshape(100, 10, order='F'),
+    np.linspace(1000, 1001, 1000, dtype='<f8').reshape(10, 10, 10),
 ]
 
 
 codecs = [
-    FixedScaleOffset(offset=1000, scale=10, dtype='f8', astype='i1'),
-    FixedScaleOffset(offset=1000, scale=10**2, dtype='f8', astype='i2'),
-    FixedScaleOffset(offset=1000, scale=10**6, dtype='f8', astype='i4'),
-    FixedScaleOffset(offset=1000, scale=10**12, dtype='f8', astype='i8'),
-    FixedScaleOffset(offset=1000, scale=10**12, dtype='f8'),
+    FixedScaleOffset(offset=1000, scale=10, dtype='<f8', astype='<i1'),
+    FixedScaleOffset(offset=1000, scale=10**2, dtype='<f8', astype='<i2'),
+    FixedScaleOffset(offset=1000, scale=10**6, dtype='<f8', astype='<i4'),
+    FixedScaleOffset(offset=1000, scale=10**12, dtype='<f8', astype='<i8'),
+    FixedScaleOffset(offset=1000, scale=10**12, dtype='<f8'),
 ]
 
 

--- a/numcodecs/tests/test_pickles.py
+++ b/numcodecs/tests/test_pickles.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
-import itertools
 
+import itertools
+import sys
 
 import numpy as np
-
+import pytest
 
 from numcodecs.compat import PY2
 from numcodecs.pickles import Pickle
@@ -54,5 +55,7 @@ def test_repr():
     check_repr("Pickle(protocol=-1)")
 
 
+@pytest.mark.skipif(sys.byteorder != 'little',
+                    reason='Pickle does not restore byte orders')
 def test_backwards_compatibility():
     check_backwards_compatibility(Pickle.codec_id, arrays, codecs)

--- a/numcodecs/tests/test_quantize.py
+++ b/numcodecs/tests/test_quantize.py
@@ -14,20 +14,20 @@ from numcodecs.tests.common import check_encode_decode, check_config, \
 
 
 arrays = [
-    np.linspace(100, 200, 1000, dtype='f8'),
-    np.random.normal(loc=0, scale=1, size=1000).astype('f8'),
-    np.linspace(100, 200, 1000, dtype='f8').reshape(100, 10),
-    np.linspace(100, 200, 1000, dtype='f8').reshape(100, 10, order='F'),
-    np.linspace(100, 200, 1000, dtype='f8').reshape(10, 10, 10),
+    np.linspace(100, 200, 1000, dtype='<f8'),
+    np.random.normal(loc=0, scale=1, size=1000).astype('<f8'),
+    np.linspace(100, 200, 1000, dtype='<f8').reshape(100, 10),
+    np.linspace(100, 200, 1000, dtype='<f8').reshape(100, 10, order='F'),
+    np.linspace(100, 200, 1000, dtype='<f8').reshape(10, 10, 10),
 ]
 
 
 codecs = [
-    Quantize(digits=-1, dtype='f8', astype='f2'),
-    Quantize(digits=0, dtype='f8', astype='f2'),
-    Quantize(digits=1, dtype='f8', astype='f2'),
-    Quantize(digits=5, dtype='f8', astype='f4'),
-    Quantize(digits=12, dtype='f8', astype='f8'),
+    Quantize(digits=-1, dtype='<f8', astype='<f2'),
+    Quantize(digits=0, dtype='<f8', astype='<f2'),
+    Quantize(digits=1, dtype='<f8', astype='<f2'),
+    Quantize(digits=5, dtype='<f8', astype='<f4'),
+    Quantize(digits=12, dtype='<f8', astype='<f8'),
 ]
 
 


### PR DESCRIPTION
Essentially, the test data is little-endian, but the test setup is imprecise and uses native endianness. This causes failures when checking results. See commit messages for more information.

* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [?] ``tox -e py27`` passes locally
* [N/A] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [N/A] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
