### PR TITLE
Allow pickles when loading test fixture data.

### DIFF
--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -187,7 +187,7 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
 
         # setup
         i = int(arr_fn.split('.')[-2])
-        arr = np.load(arr_fn)
+        arr = np.load(arr_fn, allow_pickle=True)
         arr_bytes = arr.tobytes(order='A')
         if arr.flags.f_contiguous:
             order = 'F'


### PR DESCRIPTION
NumPy disabled loading pickles because it was a security risk, but the test fixture data is test data we need to load as pickles.

This is still a security risk though, and just a stopgap solution. See #189.

TODO:
* [-] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [-] Docstrings and API docs for any new/modified user-facing classes and functions
* [-] Changes documented in docs/release.rst
* [-] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
