### PR TITLE
BUG: update c-blosc to 1.17.0 fix compilation on newer compilers

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,6 +15,10 @@ Release notes
 * Update Cython to 0.29.6.
   By :user:`John Kirkham <jakirkham>`, :issue:`168`, :issue:`177`.
 
+* The bundled c-blosc sources have been upgraded to version 1.17.0.
+  This fixes compilation with newer versions of gcc.
+  By :user:`Joe Jevnik <llllllllll>`
+
 
 .. _release_0.6.2:
 


### PR DESCRIPTION
Update c-blosc to 1.17.0 to fix compilation errors about a conflicting
definition for `_xgetbv`. This affected at least gcc-9.

TODO:
* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [x] Docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in docs/release.rst
* [x] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)

Would the zarr-developers team like me to add a newer gcc/clang to the build matrix to test for these issues in the future?
