### PR TITLE
BLD: don't mask compile errors in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -358,12 +358,4 @@ def run_setup(with_extensions):
 if __name__ == '__main__':
     is_pypy = hasattr(sys, 'pypy_translation_info')
     with_extensions = not is_pypy and 'DISABLE_NUMCODECS_CEXT' not in os.environ
-
-    try:
-        run_setup(with_extensions)
-    except BuildFailed:
-        error('*' * 75)
-        error('compilation of C extensions failed.')
-        error('retrying installation without C extensions...')
-        error('*' * 75)
-        run_setup(False)
+    run_setup(with_extensions)


### PR DESCRIPTION
pip will not display stdio unless setup.py exits with failure. The current
technique of attempting to compile, then falling back to installing without
extensions doesn't report anything to the user, which can lead to confusion when
certain codecs aren't visible.

This change just removes the fallback, if users would like to install without
extensions, they must pass the (existing) `DISABLE_NUMCODECS_CEXT=1` envvar.

Closes https://github.com/zarr-developers/numcodecs/issues/196

TODO:
* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py37`` passes locally
* [x] ``tox -e py27`` passes locally
* [x] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [x] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
