### PR TITLE
Rewrites the `ensure_text` implementation

### DIFF
--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -2,6 +2,7 @@
 # flake8: noqa
 from __future__ import absolute_import, print_function, division
 import sys
+import codecs
 import array
 
 
@@ -27,10 +28,10 @@ else:  # pragma: py2 no cover
 
 
 def ensure_text(l, encoding='utf-8'):
-    if isinstance(l, text_type):
-        return l
-    else:  # pragma: py3 no cover
-        return text_type(l, encoding=encoding)
+    if not isinstance(l, text_type):
+        l = ensure_contiguous_ndarray(l)
+        l = codecs.decode(l, 'ascii')
+    return l
 
 
 def ensure_ndarray(buf):

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -27,11 +27,11 @@ else:  # pragma: py2 no cover
     from functools import reduce
 
 
-def ensure_text(l, encoding='utf-8'):
-    if not isinstance(l, text_type):
-        l = ensure_contiguous_ndarray(l)
-        l = codecs.decode(l, 'ascii')
-    return l
+def ensure_text(s, encoding='utf-8'):
+    if not isinstance(s, text_type):
+        s = ensure_contiguous_ndarray(s)
+        s = codecs.decode(s, 'ascii')
+    return s
 
 
 def ensure_ndarray(buf):

--- a/numcodecs/tests/test_compat.py
+++ b/numcodecs/tests/test_compat.py
@@ -8,7 +8,19 @@ import numpy as np
 import pytest
 
 
-from numcodecs.compat import ensure_bytes, PY2, ensure_contiguous_ndarray
+from numcodecs.compat import ensure_text, ensure_bytes, PY2, ensure_contiguous_ndarray, text_type
+
+
+def test_ensure_text():
+    bufs = [
+        b'adsdasdas',
+        u'adsdasdas',
+        np.asarray(memoryview(b'adsdasdas')),
+        array.array('B', b'qwertyuiqwertyui')
+    ]
+    for buf in bufs:
+        b = ensure_text(buf)
+        assert isinstance(b, text_type)
 
 
 def test_ensure_bytes():


### PR DESCRIPTION
Borrows the `ensure_text_type` function's implementation from Zarr and uses it to rewrite the `ensure_text` function. Basically it makes sure any `bytes`-like data can be encoded as text with zero-copy. Also avoids getting muddled in Python 2/3 details as well, which should make it easier to maintain.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
