### PR TITLE
Use provided encoding in `ensure_text`

### DIFF
--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -30,7 +30,7 @@ else:  # pragma: py2 no cover
 def ensure_text(s, encoding='utf-8'):
     if not isinstance(s, text_type):
         s = ensure_contiguous_ndarray(s)
-        s = codecs.decode(s, 'ascii')
+        s = codecs.decode(s, encoding)
     return s
 
 


### PR DESCRIPTION
Follow-up to PR ( https://github.com/zarr-developers/numcodecs/pull/201 ), which fixes a typo in `ensure_text`.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
