### PR TITLE
Move `ensure_text` after `ensure_bytes`

### DIFF
--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -27,13 +27,6 @@ else:  # pragma: py2 no cover
     from functools import reduce
 
 
-def ensure_text(s, encoding='utf-8'):
-    if not isinstance(s, text_type):
-        s = ensure_contiguous_ndarray(s)
-        s = codecs.decode(s, encoding)
-    return s
-
-
 def ensure_ndarray(buf):
     """Convenience function to coerce `buf` to a numpy array, if it is not already a
     numpy array.
@@ -162,6 +155,13 @@ def ensure_bytes(buf):
         buf = arr.tobytes(order='A')
 
     return buf
+
+
+def ensure_text(s, encoding='utf-8'):
+    if not isinstance(s, text_type):
+        s = ensure_contiguous_ndarray(s)
+        s = codecs.decode(s, encoding)
+    return s
 
 
 def ndarray_copy(src, dst):


### PR DESCRIPTION
Mainly a cosmetic change to group like functions together. Also moves `ensure_text` after `ensure_contiguous_ndarray` and `ensure_ndarray` so the definitions of those functions are already clear.


TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py37`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
