### PR TITLE
Note Python 3.8 Support

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -49,6 +49,9 @@ Release notes
 * Use ``ensure_text`` in JSON codecs.
   By :user:`John Kirkham <jakirkham>`, :issue:`207`.
 
+* Support Python 3.8.
+  By :user:`John Kirkham <jakirkham>`, :issue:`208`.
+
 
 .. _release_0.6.3:
 


### PR DESCRIPTION


TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py38`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
