### PR TITLE
Force `libc++` on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ elif os.name == 'posix':
 # workaround lack of support for "inline" in MSVC when building for Python 2.7 64-bit
 if PY2 and os.name == 'nt':
     base_compile_args.append('-Dinline=__inline')
-# Force libc++ in case the system tries to use `stdlibc++`, which is often
-# absent from systems.
+# On macOS, force libc++ in case the system tries to use `stdlibc++`.
+# The latter is often absent from modern macOS systems.
 if sys.platform == 'darwin':
     base_compile_args.append('-stdlib=libc++')
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,10 @@ elif os.name == 'posix':
 # workaround lack of support for "inline" in MSVC when building for Python 2.7 64-bit
 if PY2 and os.name == 'nt':
     base_compile_args.append('-Dinline=__inline')
+# Force libc++ in case the system tries to use `stdlibc++`, which is often
+# absent from systems.
+if sys.platform == 'darwin':
+    base_compile_args.append('-stdlib=libc++')
 
 
 def info(*msg):


### PR DESCRIPTION
Some Python builds still try to use `stdlibc++`, which really doesn't exist on macOS any more. So force `libc++` to bypass this issue.

Note: Hopefully addresses the macOS part of issue ( https://github.com/zarr-developers/numcodecs/issues/210 ).

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py38`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
