### PR TITLE
Fix coveralls coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pytest -v --pyargs numcodecs; fi
 
 after_success:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then coveralls; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then coveralls --service=travis-pro; fi
 


### PR DESCRIPTION
See https://github.com/zarr-developers/zarr-python/pull/541 on zarr-python

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py38`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
