### PR TITLE
Move OSX CI builds to GitHub Actions

### DIFF
--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -1,0 +1,33 @@
+name: OSX CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.5", "3.6", "3.7", "3.8"]
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      
+      - name: Install numcodecs
+        run: |
+          python -m pip install -U pip setuptools wheel pytest
+          python -m pip install -v -e .
+
+      - name: List installed packages
+        run: python -m pip list
+
+      - name: Run tests
+        run: pytest -v --pyargs numcodecs

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,14 @@ matrix:
       python: 3.8
       dist: xenial
       sudo: true
-    - os: osx
-      language: generic
 
 install:
   - pip install -U tox-travis coveralls pip setuptools wheel pytest
   - pip install -v -e .
 
 script:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then tox; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pytest -v --pyargs numcodecs; fi
+  - tox
 
 after_success:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then coveralls --service=travis-pro; fi
+  - coveralls --service=travis-pro
 


### PR DESCRIPTION
This PR moves our OSX CI builds over to GitHub Actions.

cc @jakirkham 

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py38`` passes locally
* [ ] ``tox -e py27`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
