### PR TITLE
Build wheels on github actions

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -11,7 +11,8 @@ jobs:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]
     env:
-      CIBW_TEST_COMAND: pytest --pyargs numcodecs
+      CIBW_TEST_COMMAND: pytest --pyargs numcodecs
+      CIBW_TEST_REQUIRES: pytest
       CIBW_SKIP: "*27* pp*"
       CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.9"
 

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -1,0 +1,38 @@
+name: Wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+    env:
+      CIBW_TEST_COMAND: pytest --pyargs numcodecs
+      CIBW_SKIP: "*27* pp*"
+      CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.9"
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v1
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==1.3.0
+
+      - name: Build wheel
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+      - uses: actions/upload-artifact@v1
+        with:
+          name: wheels
+          path: ./wheelhouse


### PR DESCRIPTION
Build wheel on github actions using cibuildwheel. Cibuildwheel maintainers will fix most of problems with build system during development. 

This PR contains only build wheel. Then it need to be manually uploaded to pypi.org. It is possible to ad such step to this. 

Fixes #70 

EDIT. 
There is no such tools like dealocate or audithweel for windows, so maybe someone can check windows wheel on his machine. 
