### PR TITLE
Use pytest to parametrize some of the tests.

### DIFF
--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -1,4 +1,3 @@
-import itertools
 from multiprocessing import Pool
 from multiprocessing.pool import ThreadPool
 
@@ -53,9 +52,15 @@ arrays = [
 ]
 
 
-def test_encode_decode():
-    for arr, codec in itertools.product(arrays, codecs):
-        check_encode_decode(arr, codec)
+@pytest.fixture(scope='module', params=[True, False, None])
+def use_threads(request):
+    return request.param
+
+
+@pytest.mark.parametrize('array', arrays)
+@pytest.mark.parametrize('codec', codecs)
+def test_encode_decode(array, codec):
+    check_encode_decode(array, codec)
 
 
 def test_config():
@@ -88,30 +93,34 @@ def test_eq():
     assert Blosc(cname='lz4') != 'foo'
 
 
-def test_compress_blocksize():
+def test_compress_blocksize_default(use_threads):
     arr = np.arange(1000, dtype='i4')
 
-    for use_threads in True, False, None:
-        blosc.use_threads = use_threads
+    blosc.use_threads = use_threads
 
-        # default blocksize
-        enc = blosc.compress(arr, b'lz4', 1, Blosc.NOSHUFFLE)
-        _, _, blocksize = blosc.cbuffer_sizes(enc)
-        assert blocksize > 0
+    # default blocksize
+    enc = blosc.compress(arr, b'lz4', 1, Blosc.NOSHUFFLE)
+    _, _, blocksize = blosc.cbuffer_sizes(enc)
+    assert blocksize > 0
 
-        # explicit default blocksize
-        enc = blosc.compress(arr, b'lz4', 1, Blosc.NOSHUFFLE, 0)
-        _, _, blocksize = blosc.cbuffer_sizes(enc)
-        assert blocksize > 0
-
-        # custom blocksize
-        for bs in 2**7, 2**8:
-            enc = blosc.compress(arr, b'lz4', 1, Blosc.NOSHUFFLE, bs)
-            _, _, blocksize = blosc.cbuffer_sizes(enc)
-            assert blocksize == bs
+    # explicit default blocksize
+    enc = blosc.compress(arr, b'lz4', 1, Blosc.NOSHUFFLE, 0)
+    _, _, blocksize = blosc.cbuffer_sizes(enc)
+    assert blocksize > 0
 
 
-def test_compress_complib():
+@pytest.mark.parametrize('bs', (2**7, 2**8))
+def test_compress_blocksize(use_threads, bs):
+    arr = np.arange(1000, dtype='i4')
+
+    blosc.use_threads = use_threads
+
+    enc = blosc.compress(arr, b'lz4', 1, Blosc.NOSHUFFLE, bs)
+    _, _, blocksize = blosc.cbuffer_sizes(enc)
+    assert blocksize == bs
+
+
+def test_compress_complib(use_threads):
     arr = np.arange(1000, dtype='i4')
     expected_complibs = {
         'lz4': 'LZ4',
@@ -121,48 +130,45 @@ def test_compress_complib():
         'zlib': 'Zlib',
         'zstd': 'Zstd',
     }
-    for use_threads in True, False, None:
+    blosc.use_threads = use_threads
+    for cname in blosc.list_compressors():
+        enc = blosc.compress(arr, cname.encode(), 1, Blosc.NOSHUFFLE)
+        complib = blosc.cbuffer_complib(enc)
+        expected_complib = expected_complibs[cname]
+        assert complib == expected_complib
+    with pytest.raises(ValueError):
+        # capitalized cname
+        blosc.compress(arr, b'LZ4', 1)
+    with pytest.raises(ValueError):
+        # bad cname
+        blosc.compress(arr, b'foo', 1)
+
+
+@pytest.mark.parametrize('dtype', ['i1', 'i2', 'i4', 'i8'])
+def test_compress_metainfo(dtype, use_threads):
+    arr = np.arange(1000, dtype=dtype)
+    for shuffle in Blosc.NOSHUFFLE, Blosc.SHUFFLE, Blosc.BITSHUFFLE:
         blosc.use_threads = use_threads
         for cname in blosc.list_compressors():
-            enc = blosc.compress(arr, cname.encode(), 1, Blosc.NOSHUFFLE)
-            complib = blosc.cbuffer_complib(enc)
-            expected_complib = expected_complibs[cname]
-            assert complib == expected_complib
-        with pytest.raises(ValueError):
-            # capitalized cname
-            blosc.compress(arr, b'LZ4', 1)
-        with pytest.raises(ValueError):
-            # bad cname
-            blosc.compress(arr, b'foo', 1)
+            enc = blosc.compress(arr, cname.encode(), 1, shuffle)
+            typesize, did_shuffle, _ = blosc.cbuffer_metainfo(enc)
+            assert typesize == arr.dtype.itemsize
+            assert did_shuffle == shuffle
 
 
-def test_compress_metainfo():
-    for dtype in 'i1', 'i2', 'i4', 'i8':
-        arr = np.arange(1000, dtype=dtype)
-        for shuffle in Blosc.NOSHUFFLE, Blosc.SHUFFLE, Blosc.BITSHUFFLE:
-            for use_threads in True, False, None:
-                blosc.use_threads = use_threads
-                for cname in blosc.list_compressors():
-                    enc = blosc.compress(arr, cname.encode(), 1, shuffle)
-                    typesize, did_shuffle, _ = blosc.cbuffer_metainfo(enc)
-                    assert typesize == arr.dtype.itemsize
-                    assert did_shuffle == shuffle
-
-
-def test_compress_autoshuffle():
+def test_compress_autoshuffle(use_threads):
     arr = np.arange(8000)
     for dtype in 'i1', 'i2', 'i4', 'i8', 'f2', 'f4', 'f8', 'bool', 'S10':
         varr = arr.view(dtype)
-        for use_threads in True, False, None:
-            blosc.use_threads = use_threads
-            for cname in blosc.list_compressors():
-                enc = blosc.compress(varr, cname.encode(), 1, Blosc.AUTOSHUFFLE)
-                typesize, did_shuffle, _ = blosc.cbuffer_metainfo(enc)
-                assert typesize == varr.dtype.itemsize
-                if typesize == 1:
-                    assert did_shuffle == Blosc.BITSHUFFLE
-                else:
-                    assert did_shuffle == Blosc.SHUFFLE
+        blosc.use_threads = use_threads
+        for cname in blosc.list_compressors():
+            enc = blosc.compress(varr, cname.encode(), 1, Blosc.AUTOSHUFFLE)
+            typesize, did_shuffle, _ = blosc.cbuffer_metainfo(enc)
+            assert typesize == varr.dtype.itemsize
+            if typesize == 1:
+                assert did_shuffle == Blosc.BITSHUFFLE
+            else:
+                assert did_shuffle == Blosc.SHUFFLE
 
 
 def test_config_blocksize():
@@ -196,28 +202,29 @@ def _decode_worker(enc):
     return data
 
 
-def test_multiprocessing():
+@pytest.mark.parametrize('pool', (Pool, ThreadPool))
+def test_multiprocessing(use_threads, pool):
     data = np.arange(1000000)
     enc = _encode_worker(data)
 
+    pool = pool(5)
+
     try:
-        for use_threads in None, True, False:
-            blosc.use_threads = use_threads
+        blosc.use_threads = use_threads
 
-            # test with process pool and thread pool
-            for pool in Pool(5), ThreadPool(5):
+        # test with process pool and thread pool
 
-                # test encoding
-                enc_results = pool.map(_encode_worker, [data] * 5)
-                assert all([len(enc) == len(e) for e in enc_results])
+        # test encoding
+        enc_results = pool.map(_encode_worker, [data] * 5)
+        assert all([len(enc) == len(e) for e in enc_results])
 
-                # test decoding
-                dec_results = pool.map(_decode_worker, [enc] * 5)
-                assert all([data.nbytes == len(d) for d in dec_results])
+        # test decoding
+        dec_results = pool.map(_decode_worker, [enc] * 5)
+        assert all([data.nbytes == len(d) for d in dec_results])
 
-                # tidy up
-                pool.close()
-                pool.join()
+        # tidy up
+        pool.close()
+        pool.join()
 
     finally:
         blosc.use_threads = None  # restore default


### PR DESCRIPTION
This basically move the looping on multiple conditions from being the
test responsibility to being pytest's it has several advantages.

1) I find it make the test more redable as you only have to focus on
   what you want to test.

2) In case of test failures it will have more informative message with
   which sub-condition fails and will not stop on the first error,
   usually allowing to narrow down the error case faster.

3) It allow to run a single subtest when fixing code (using the --lf, or
   --ff pytest flags).

4) Show which subcase are slow with --durations=..., and could integrade
   with multi-worker testing or randomisations.

It does have minimal drawbacks; but this does increase some of the setup
time which is now done sometime for each case instead of one per group.

use_threads seem to be used a lot, so I made it a module-scoped fixture,
a function only have to use the parameter use_threads to automatically
been generic over some parameters, other are ad-hoc.

I did not parametrize on everything as I mostly want to test if you are
ok with this approach.

This was initially push by trying to test current decode_partial in
blosc which is still in progress and was failing on a subset of cases.

--- 

GitHub note, the diff will me messy if you don't "ignore whitespace", most of the changes are de-indent and removal of for loops.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py38`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
