### PR TITLE
Use unambiguous variable name

### DIFF
--- a/numcodecs/categorize.py
+++ b/numcodecs/categorize.py
@@ -43,7 +43,7 @@ class Categorize(Codec):
         if self.dtype.kind not in 'UO':
             raise TypeError("only unicode ('U') and object ('O') dtypes are "
                             "supported")
-        self.labels = [ensure_text(l) for l in labels]
+        self.labels = [ensure_text(label) for label in labels]
         self.astype = np.dtype(astype)
         if self.astype == object:
             raise TypeError('encoding as object array not supported')


### PR DESCRIPTION
This PR fixes a `flake8` issue in `master`:

```
$ flake8 numcodecs
numcodecs/categorize.py:46:43: E741 ambiguous variable name 'l'
```

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py38`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
