### PR TITLE
Add Base64 codec

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -4,6 +4,9 @@ Release notes
 Upcoming Release
 ----------------
 
+* Add Base64 codec.
+  By :user: `Trevor Manz <manzt>`, :issue: `176`.
+
 * Add partial decompression of Blosc compressed arrays.
   By :user:`Andrew Fulton <andrewfulton9>`, :issue:`235`.
 

--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -89,6 +89,9 @@ register_codec(Categorize)
 from numcodecs.pickles import Pickle
 register_codec(Pickle)
 
+from numcodecs.base64 import Base64
+register_codec(Base64)
+
 try:
     from numcodecs.msgpacks import MsgPack
     register_codec(MsgPack)

--- a/numcodecs/base64.py
+++ b/numcodecs/base64.py
@@ -1,0 +1,28 @@
+import base64 as _base64
+import io
+
+from .abc import Codec
+from .compat import ensure_contiguous_ndarray, ndarray_copy
+
+
+class Base64(Codec):
+    """Codec providing base64 compression via the Python standard library."""
+
+    codec_id = "base64"
+
+    def encode(self, buf):
+        # normalise inputs
+        buf = ensure_contiguous_ndarray(buf)
+        # do compression
+        compressed = _base64.standard_b64encode(buf)
+        return compressed
+
+    def decode(self, buf, out=None):
+        # normalise inputs
+        buf = ensure_contiguous_ndarray(buf)
+        if out is not None:
+            out = ensure_contiguous_ndarray(out)
+        # do decompression
+        decompressed = _base64.standard_b64decode(buf)
+        # handle destination
+        return ndarray_copy(decompressed, out)

--- a/numcodecs/base64.py
+++ b/numcodecs/base64.py
@@ -1,5 +1,4 @@
 import base64 as _base64
-import io
 
 from .abc import Codec
 from .compat import ensure_contiguous_ndarray, ndarray_copy

--- a/numcodecs/tests/test_base64.py
+++ b/numcodecs/tests/test_base64.py
@@ -8,12 +8,10 @@ import pytest
 from numcodecs.base64 import Base64
 from numcodecs.tests.common import (
     check_encode_decode,
-    check_config,
     check_repr,
     check_backwards_compatibility,
     check_err_decode_object_buffer,
     check_err_encode_object_buffer,
-    greetings,
 )
 
 

--- a/numcodecs/tests/test_base64.py
+++ b/numcodecs/tests/test_base64.py
@@ -1,0 +1,86 @@
+import itertools
+
+
+import numpy as np
+import pytest
+
+
+from numcodecs.base64 import Base64
+from numcodecs.tests.common import (
+    check_encode_decode,
+    check_config,
+    check_repr,
+    check_backwards_compatibility,
+    check_err_decode_object_buffer,
+    check_err_encode_object_buffer,
+    greetings,
+)
+
+
+codecs = [
+    Base64(),
+]
+
+
+# mix of dtypes: integer, float, bool, string
+# mix of shapes: 1D, 2D, 3D
+# mix of orders: C, F
+arrays = [
+    np.arange(1000, dtype="i4"),
+    np.linspace(1000, 1001, 1000, dtype="f8"),
+    np.random.normal(loc=1000, scale=1, size=(100, 10)),
+    np.random.randint(0, 2, size=1000, dtype=bool).reshape(100, 10, order="F"),
+    np.random.choice([b"a", b"bb", b"ccc"], size=1000).reshape(10, 10, 10),
+    np.random.randint(0, 2 ** 60, size=1000, dtype="u8").view("M8[ns]"),
+    np.random.randint(0, 2 ** 60, size=1000, dtype="u8").view("m8[ns]"),
+    np.random.randint(0, 2 ** 25, size=1000, dtype="u8").view("M8[m]"),
+    np.random.randint(0, 2 ** 25, size=1000, dtype="u8").view("m8[m]"),
+    np.random.randint(-(2 ** 63), -(2 ** 63) + 20, size=1000, dtype="i8").view("M8[ns]"),
+    np.random.randint(-(2 ** 63), -(2 ** 63) + 20, size=1000, dtype="i8").view("m8[ns]"),
+    np.random.randint(-(2 ** 63), -(2 ** 63) + 20, size=1000, dtype="i8").view("M8[m]"),
+    np.random.randint(-(2 ** 63), -(2 ** 63) + 20, size=1000, dtype="i8").view("m8[m]"),
+]
+
+
+def test_encode_decode():
+    for arr, codec in itertools.product(arrays, codecs):
+        check_encode_decode(arr, codec)
+
+
+def test_repr():
+    check_repr("Base64()")
+
+
+def test_eq():
+    assert Base64() == Base64()
+    assert not Base64() != Base64()
+    assert Base64() != "foo"
+    assert "foo" != Base64()
+    assert not Base64() == "foo"
+
+
+def test_backwards_compatibility():
+    check_backwards_compatibility(Base64.codec_id, arrays, codecs)
+
+
+def test_err_decode_object_buffer():
+    check_err_decode_object_buffer(Base64())
+
+
+def test_err_encode_object_buffer():
+    check_err_encode_object_buffer(Base64())
+
+
+def test_err_encode_list():
+    data = ["foo", "bar", "baz"]
+    for codec in codecs:
+        with pytest.raises(TypeError):
+            codec.encode(data)
+
+
+def test_err_encode_non_contiguous():
+    # non-contiguous memory
+    arr = np.arange(1000, dtype="i4")[::2]
+    for codec in codecs:
+        with pytest.raises(ValueError):
+            codec.encode(arr)


### PR DESCRIPTION
I came across #176 when looking for codecs to add to `numcodecs.js`, and it only took a few minutes to implement. One thing to note is that I used the `base64.standard_b64encode` and `base64.standard_b64decode` which use the standard Base64 alphabet. The standard `base64` module also includes [`base64.encode`](https://docs.python.org/3/library/base64.html#base64.b64encode) and [`base64.decode`](https://docs.python.org/3/library/base64.html#base64.b64decode) which take an optional `altchars` argument for specifying an alternate alphabet, but I'm not sure how common that is.

TODO:
* [x] Unit tests and/or doctests in docstrings
* [x] ``tox -e py38`` passes locally
* [x] Docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in docs/release.rst
* [x] ``tox -e docs`` passes locally
* [x] AppVeyor and Travis CI passes
* [x] Test coverage to 100% (Coveralls passes)
