### PR TITLE
Release 0.7.0

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -37,3 +37,37 @@ jobs:
         with:
           name: wheels
           path: ./wheelhouse
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          # To test: repository_url: https://test.pypi.org/legacy/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,6 +91,9 @@ documentation, code reviews, comments and/or ideas:
 * :user:`John Kirkham <jakirkham>`
 * :user:`Alistair Miles <alimanfoo>`
 * :user:`Jeff Reback <jreback>`
+* :user:`Trevor Manz <manzt>`
+* :user:`Grzegorz Bokota <Czaki>`
+* :user:`Josh Moore <joshmoore>`
 
 Numcodecs bundles the `c-blosc <https://github.com/Blosc/c-blosc>`_ library.
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,8 +1,10 @@
 Release notes
 =============
 
-Upcoming Release
-----------------
+.. _release_0.7.0:
+
+0.7.0
+-----
 
 * Add Base64 codec.
   By :user: `Trevor Manz <manzt>`, :issue: `176`.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,8 +6,14 @@ Release notes
 0.7.0
 -----
 
+* Automatically release to PyPI.
+  By :user:`Josh Moore <joshmoore>`, :issue:`241`.
+
+* Build wheels on github actions.
+  By :user:`Grzegorz Bokota <Czaki>`, :issue:`224`.
+
 * Add Base64 codec.
-  By :user: `Trevor Manz <manzt>`, :issue: `176`.
+  By :user:`Trevor Manz <manzt>`, :issue:`176`.
 
 * Add partial decompression of Blosc compressed arrays.
   By :user:`Andrew Fulton <andrewfulton9>`, :issue:`235`.


### PR DESCRIPTION
Following on from #224, these are the steps I'm assuming are required for a release with the wheels (feedback _very_ welcome):

 - [x] Bump minor version due to the drop of Python 2
 - [x] Bump docs/release.rst
 - If manual:
   - [ ] Tag & push to trigger wheel build
   - [ ] Wait on wheels to build then download
   - [ ] Extend the instructions in release.txt in upload the sdist as well as the wheels.
 - Or for an automatic deploy:
   - [x] introduce new PyPI user ("zarr_dev") for uploading.
   - [x] Introduce a new GitHub workflow to perform the above.
   - [ ] (Optionally merge PR and) push v0.7.0.rc1 tag to test push to pypi
   - [ ] Push v0.7.0 tag and hope for an automated release 🤞  

