### PR TITLE
Enable C-extensions on PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
   include:
     - os: linux
       language: python
+      python: pypy3
+    - os: linux
+      language: python
       python: 3.5
     - os: linux
       language: python

--- a/setup.py
+++ b/setup.py
@@ -345,6 +345,5 @@ def run_setup(with_extensions):
 
 
 if __name__ == '__main__':
-    is_pypy = hasattr(sys, 'pypy_translation_info')
-    with_extensions = not is_pypy and 'DISABLE_NUMCODECS_CEXT' not in os.environ
+    with_extensions = 'DISABLE_NUMCODECS_CEXT' not in os.environ
     run_setup(with_extensions)


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/numcodecs/issues/238

Enables C-extensions support on PyPy (Cython support on PyPy has come a long ways). Also adds a [Travis CI job for PyPy]( https://docs.travis-ci.com/user/languages/python/#pypy-support ). Appears [AppVeyor does not officially support PyPy yet]( https://www.appveyor.com/docs/lang/python/#testing-against-pypy ). Haven't dug into how to do this on GitHub Workflows. Another question here would be building wheels for PyPy (maybe @Czaki has thoughts? 🙂).

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py38`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
