### PR TITLE
Clean fixtures

### DIFF
--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -302,6 +302,10 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
                     assert_array_equal(arr, dec_arr)
                     assert arr_bytes == ensure_bytes(dec)
 
+    if os.path.exists(fixture_dir):
+        import shutil
+        shutil.rmtree(fixture_dir)
+
 
 def check_err_decode_object_buffer(compressor):
     # cannot decode directly into object array, leads to segfaults


### PR DESCRIPTION
The PR adds some cleanup code to ``check_backwards_compatibility`` to remove test artefacts form the source tree.

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py38`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
