### PR TITLE
Try to migrate to Gh-action.

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -1,0 +1,41 @@
+name: Linux CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: linux
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.5", "3.6", "3.7", "3.8"]
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install numcodecs
+        run: |
+          python -m pip install -U pip setuptools wheel pytest tox -rrequirements_dev.txt -rrequirements_rtfd.txt
+          python -m pip install -v -e .
+
+      - name: List installed packages
+        run: python -m pip list
+
+      - name: Run tests
+        run: pytest -v --cov=numcodecs --doctest-modules --doctest-glob=*.pyx numcodecs
+
+      - name: Flake8
+        run: flake8 numcodecs
+
+      - name: Build Doc:
+        run: |
+          cd docs
+          sphinx-build -W -b html


### PR DESCRIPTION
As we are out of time on .travis-ci for the zarr org.

[Description of PR]

TODO:
* [ ] Unit tests and/or doctests in docstrings
* [ ] ``tox -e py38`` passes locally
* [ ] Docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes documented in docs/release.rst
* [ ] ``tox -e docs`` passes locally
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
