### PR TITLE
Drop out-of-date manual release upload doc bit

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -307,10 +307,3 @@ Tag the version (where "X.X.X" stands for the version number, e.g., "2.2.0")::
 
 This will trigger a GitHub Action which will build the source
 distribution as well as wheels for all major platforms.
-
-Obtain checksum for release to conda-forge::
-
-    $ openssl sha256 dist/numcodecs-${version}.tar.gz
-
-Release to conda-forge by making a pull request against the numcodecs-feedstock conda-forge
-repository, incrementing the version number.


### PR DESCRIPTION
This is a hold over from when we uploaded binaries manually. We no longer need it now that releases are done on CI. So drop this text.

xref: https://github.com/zarr-developers/numcodecs/pull/270#issuecomment-767414298

cc @joshmoore

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
