### PR TITLE
Fix expected result test for Shuffle.

### DIFF
--- a/numcodecs/tests/test_shuffle.py
+++ b/numcodecs/tests/test_shuffle.py
@@ -133,15 +133,24 @@ def test_backwards_compatibility():
 #             codec.decode(bytearray(0))
 
 def test_expected_result():
-    # Each byte of the 4 byte uint64 is shuffled in such a way
-    # that for an array of length 4, the last byte of the last
-    # element becomes the first byte of the first element
-    # therefore [0, 0, 0, 1] becomes [2**((len-1)*8), 0, 0, 0]
-    # (where 8 = bits in a byte)
-    arr = np.array([0, 0, 0, 1], dtype='uint64')
+    # If the input is treated as a 2D byte array, with shape (size of element, number of elements),
+    # the shuffle is essentially a transpose. This can be made more apparent by using an array of
+    # big-endian integers, as below.
+    arr = np.array([0x0001020304050607, 0x08090a0b0c0d0e0f, 0x1011121314151617, 0x18191a1b1c1d1e1f],
+                   dtype='>u8')
+    expected = np.array([
+        0x00081018,
+        0x01091119,
+        0x020a121a,
+        0x030b131b,
+        0x040c141c,
+        0x050d151d,
+        0x060e161e,
+        0x070f171f,
+    ], dtype='u4')
     codec = Shuffle(elementsize=arr.data.itemsize)
     enc = codec.encode(arr)
-    assert np.frombuffer(enc.data, arr.dtype)[0] == 2**((len(arr)-1)*8)
+    np.testing.assert_array_equal(np.frombuffer(enc.data, '>u4'), expected)
 
 
 def test_incompatible_elementsize():


### PR DESCRIPTION
The explanatory comment incorrectly states that uint64 is 4 bytes, which made the math very confusing. It also did not work on big-endian systems, since everything is swapped from what it assumes.

Using an explicit order fixes it on both systems, and big-endian makes it easier to reason about since the typed-in values look the same as the layout in memory.

PS, I found it difficult to understand what the shuffle filter was from the docs. Eventually, I found [the HDF5 docs](https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_shuffle.htm), and I hope that is the right interpretation.

- [x] Unit tests and/or doctests in docstrings
- [x] `tox -e py39` passes locally
- [n/a] Docstrings and API docs for any new/modified user-facing classes and functions
- [n/a] Changes documented in docs/release.rst
- [n/a] `tox -e docs` passes locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Coveralls passes)

fix #286 