### PR TITLE
Fix an ImportError w/Blosc on Android

### DIFF
--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -79,6 +79,8 @@ try:
     mutex = multiprocessing.Lock()
 except OSError:
     mutex = None
+except ImportError:
+    mutex = None
 
 # store ID of process that first loads the module, so we can detect a fork later
 _importer_pid = os.getpid()


### PR DESCRIPTION
Android does not have a functioning semaphore system (actually it's
    bionic-C that doesn't...). When trying to import numcodecs.blosc on
Android, an ImportError exception was thrown - which was unhandled.

[Description of PR]

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
