### PR TITLE
fix inaccurate docstrings

### DIFF
--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -525,7 +525,7 @@ class Blosc(Codec):
     clevel : integer, optional
         An integer between 0 and 9 specifying the compression level.
     shuffle : integer, optional
-        Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If -1,
+        Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If AUTOSHUFFLE,
         bit-shuffle will be used for buffers with itemsize 1, and byte-shuffle will
         be used otherwise. The default is `SHUFFLE`.
     blocksize : int

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -228,9 +228,9 @@ def compress(source, char* cname, int clevel, int shuffle=SHUFFLE,
     clevel : int
         Compression level.
     shuffle : int
-        Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If -1
-        (default), bit-shuffle will be used for buffers with itemsize 1,
-        and byte-shuffle will be used otherwise.
+        Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If -1,
+        bit-shuffle will be used for buffers with itemsize 1, and byte-shuffle will
+        be used otherwise.
     blocksize : int
         The requested size of the compressed blocks.  If 0, an automatic blocksize will
         be used.
@@ -525,9 +525,9 @@ class Blosc(Codec):
     clevel : integer, optional
         An integer between 0 and 9 specifying the compression level.
     shuffle : integer, optional
-        Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If -1
-        (default), bit-shuffle will be used for buffers with itemsize 1,
-        and byte-shuffle will be used otherwise.
+        Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If -1,
+        bit-shuffle will be used for buffers with itemsize 1, and byte-shuffle will
+        be used otherwise.
     blocksize : int
         The requested size of the compressed blocks.  If 0 (default), an automatic
         blocksize will be used.

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -527,7 +527,7 @@ class Blosc(Codec):
     shuffle : integer, optional
         Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If -1,
         bit-shuffle will be used for buffers with itemsize 1, and byte-shuffle will
-        be used otherwise.
+        be used otherwise. The default is `SHUFFLE`.
     blocksize : int
         The requested size of the compressed blocks.  If 0 (default), an automatic
         blocksize will be used.

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -230,7 +230,7 @@ def compress(source, char* cname, int clevel, int shuffle=SHUFFLE,
     shuffle : int
         Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If -1,
         bit-shuffle will be used for buffers with itemsize 1, and byte-shuffle will
-        be used otherwise.
+        be used otherwise. The default is `SHUFFLE`.
     blocksize : int
         The requested size of the compressed blocks.  If 0, an automatic blocksize will
         be used.

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -228,7 +228,7 @@ def compress(source, char* cname, int clevel, int shuffle=SHUFFLE,
     clevel : int
         Compression level.
     shuffle : int
-        Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If -1,
+        Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). If AUTOSHUFFLE,
         bit-shuffle will be used for buffers with itemsize 1, and byte-shuffle will
         be used otherwise. The default is `SHUFFLE`.
     blocksize : int


### PR DESCRIPTION
I noticed that the docstring for Blosc inaccurately states that -1 (`AUTOSHUFFLE`) is the default. This is confusing so I fixed it.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
