### PR TITLE
Codespell

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -108,7 +108,7 @@ report the bug or propose the feature you'd like to add.
 It's best to create a new, separate branch for each piece of work you want to do. E.g.::
 
     git fetch upstream
-    git checkout -b shiny-new-feature upsteam/master
+    git checkout -b shiny-new-feature upstream/master
 
 This changes your working directory to the 'shiny-new-feature' branch. Keep any changes in
 this branch specific to one bug or feature so it is clear what the branch brings to

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -389,7 +389,7 @@ Unreleased
 0.2.1
 -----
 
-The bundled c-blosc libary has been upgraded to version 1.11.3 (:issue:`34`, :issue:`35`).
+The bundled c-blosc library has been upgraded to version 1.11.3 (:issue:`34`, :issue:`35`).
 
 
 .. _release_0.2.0:

--- a/numcodecs/abc.py
+++ b/numcodecs/abc.py
@@ -16,7 +16,7 @@ configuration object must also contain an 'id' field storing the codec
 identifier (see below).
 
 Codec classes must implement a :func:`Codec.from_config` class method,
-which will return an instance of the class initiliazed from a configuration
+which will return an instance of the class initialized from a configuration
 object.
 
 Finally, codec classes must set a `codec_id` class-level attribute. This

--- a/numcodecs/blosc.c
+++ b/numcodecs/blosc.c
@@ -4885,7 +4885,7 @@ static PyObject *__pyx_pf_9numcodecs_5blosc_24decompress_partial(CYTHON_UNUSED P
  *     # get encoding size from source buffer header
  *     encoding_size = source[3]             # <<<<<<<<<<<<<<
  * 
- *     # convert varibles to handle type and encoding sizes
+ *     # convert variables to handle type and encoding sizes
  */
   __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_source, 3, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 435, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
@@ -4895,7 +4895,7 @@ static PyObject *__pyx_pf_9numcodecs_5blosc_24decompress_partial(CYTHON_UNUSED P
 
   /* "numcodecs/blosc.pyx":438
  * 
- *     # convert varibles to handle type and encoding sizes
+ *     # convert variables to handle type and encoding sizes
  *     nitems_bytes = nitems * encoding_size             # <<<<<<<<<<<<<<
  *     start_bytes = (start * encoding_size)
  * 
@@ -4910,7 +4910,7 @@ static PyObject *__pyx_pf_9numcodecs_5blosc_24decompress_partial(CYTHON_UNUSED P
   __pyx_v_nitems_bytes = __pyx_t_4;
 
   /* "numcodecs/blosc.pyx":439
- *     # convert varibles to handle type and encoding sizes
+ *     # convert variables to handle type and encoding sizes
  *     nitems_bytes = nitems * encoding_size
  *     start_bytes = (start * encoding_size)             # <<<<<<<<<<<<<<
  * 

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -436,7 +436,7 @@ def decompress_partial(source, start, nitems, dest=None):
     # get encoding size from source buffer header
     encoding_size = source[3]
 
-    # convert varibles to handle type and encoding sizes
+    # convert variables to handle type and encoding sizes
     nitems_bytes = nitems * encoding_size
     start_bytes = (start * encoding_size)
 

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -63,7 +63,7 @@ def ensure_contiguous_ndarray(buf, max_buffer_size=None):
         A numpy array or any object exporting a buffer interface.
     max_buffer_size : int
         If specified, the largest allowable value of arr.nbytes, where arr
-        is the retured array.
+        is the returned array.
 
     Returns
     -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git
+ignore-words-list = ba, compiletime, hist, nd, unparseable


### PR DESCRIPTION
* A few typos found by [codespell](https://github.com/codespell-project/codespell). Because `parseable->parsable` might be debated, I have fixed that typo in a separate commit.
* Add [codespell](https://github.com/codespell-project/codespell) configuration to a newly created `setup.cfg` file.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
