### PR TITLE
Unnecessary comprehension

### DIFF
--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -239,11 +239,11 @@ def test_multiprocessing(use_threads, pool):
 
         # test encoding
         enc_results = pool.map(_encode_worker, [data] * 5)
-        assert all([len(enc) == len(e) for e in enc_results])
+        assert all(len(enc) == len(e) for e in enc_results)
 
         # test decoding
         dec_results = pool.map(_decode_worker, [enc] * 5)
-        assert all([data.nbytes == len(d) for d in dec_results])
+        assert all(data.nbytes == len(d) for d in dec_results)
 
         # tidy up
         pool.close()

--- a/numcodecs/tests/test_shuffle.py
+++ b/numcodecs/tests/test_shuffle.py
@@ -103,11 +103,11 @@ def test_multiprocessing(pool):
 
     # test encoding
     enc_results = pool.map(_encode_worker, [data] * 5)
-    assert all([len(enc) == len(e) for e in enc_results])
+    assert all(len(enc) == len(e) for e in enc_results)
 
     # test decoding
     dec_results = pool.map(_decode_worker, [enc] * 5)
-    assert all([data.nbytes == len(d) for d in dec_results])
+    assert all(data.nbytes == len(d) for d in dec_results)
 
     # tidy up
     pool.close()


### PR DESCRIPTION
Built-in function [all()](https://docs.python.org/3/library/functions.html#all) does not require a comprehension, it operates directly on a generator expression.

This fixes these DeepSource.io alerts:
https://deepsource.io/gh/DimitriPapadopoulos/numcodecs/issue/PTC-W0016/occurrences
https://deepsource.io/gh/DimitriPapadopoulos/numcodecs/issue/PYL-R1721/occurrences

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
