### PR TITLE
Unused variable

### DIFF
--- a/numcodecs/tests/test_zfpy.py
+++ b/numcodecs/tests/test_zfpy.py
@@ -68,7 +68,7 @@ def test_repr():
 
 
 def test_backwards_compatibility():
-    for i, code in enumerate(codecs):
+    for code in codecs:
         if code.mode == _zfpy.mode_fixed_rate:
             codec = [code]
             check_backwards_compatibility(ZFPY.codec_id, arrays, codec)


### PR DESCRIPTION
Unused variable `i`.

This fixes a DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/numcodecs/issue/PYL-W0612/occurrences

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
