### PR TITLE
Unnecessary `None` provided to `get()`

### DIFF
--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -28,7 +28,7 @@ def get_codec(config):
     """
     config = dict(config)
     codec_id = config.pop('id', None)
-    cls = codec_registry.get(codec_id, None)
+    cls = codec_registry.get(codec_id)
     if cls is None:
         raise ValueError('codec not available: %r' % codec_id)
     return cls.from_config(config)


### PR DESCRIPTION
It is unnecessary to provide `None` as the default value when the key is not present in the dictionary as `get` implicitly returns `None`.

This fixes a DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/numcodecs/issue/PTC-W0039/occurrences

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
