### PR TITLE
Use literal syntax to create `dict` and `list`

### DIFF
--- a/numcodecs/astype.py
+++ b/numcodecs/astype.py
@@ -68,7 +68,7 @@ class AsType(Codec):
         return out
 
     def get_config(self):
-        config = dict()
+        config = {}
         config['id'] = self.codec_id
         config['encode_dtype'] = self.encode_dtype.str
         config['decode_dtype'] = self.decode_dtype.str

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -3,7 +3,7 @@ applications to dynamically register and look-up codec classes."""
 import logging
 
 logger = logging.getLogger("numcodecs")
-codec_registry = dict()
+codec_registry = {}
 entries = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ disable_avx2 = 'DISABLE_NUMCODECS_AVX2' in os.environ
 
 # setup common compile arguments
 have_cflags = 'CFLAGS' in os.environ
-base_compile_args = list()
+base_compile_args = []
 if have_cflags:
     # respect compiler options set by user
     pass
@@ -321,7 +321,7 @@ def run_setup(with_extensions):
         cmdclass = dict(build_ext=ve_build_ext)
     else:
         ext_modules = []
-        cmdclass = dict()
+        cmdclass = {}
 
     setup(
         name='numcodecs',


### PR DESCRIPTION
Using the literal syntax can give minor performance bumps compared to using function calls to create `dict`, `list` and `tuple`. 

Fixes these DeepSource.io alerts:
https://deepsource.io/gh/DimitriPapadopoulos/numcodecs/issue/PTC-W0019/occurrences

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
