### PR TITLE
Mismatched parameters in overridden method

### DIFF
--- a/numcodecs/abc.py
+++ b/numcodecs/abc.py
@@ -40,7 +40,7 @@ class Codec:
     """Codec identifier."""
 
     @abstractmethod
-    def encode(self, buf):  # pragma: no cover
+    def encode(self, buf, out=None):  # pragma: no cover
         """Encode data in `buf`.
 
         Parameters
@@ -48,6 +48,9 @@ class Codec:
         buf : buffer-like
             Data to be encoded. May be any object supporting the new-style
             buffer protocol.
+        out : buffer-like, optional
+            Writeable buffer to store encoded data. N.B. if provided, this buffer must
+            be exactly the right size to store the encoded data.
 
         Returns
         -------


### PR DESCRIPTION
Number of parameters was 2 in `Codec.encode` and is now 3 in overridden `Shuffle.encode` method.

Fixes this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/numcodecs/issue/PYL-W0221/occurrences

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
