### PR TITLE
Entrypoints

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -8,6 +8,9 @@ Unreleased
 
 .. _release_0.9.1:
 
+* Add ability to find codecs via entrypoints
+  By :user:`Martin Durant <martindurant>`, :issue:`290`.
+
 0.9.1
 -----
 

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -3,11 +3,20 @@ applications to dynamically register and look-up codec classes."""
 
 
 codec_registry = dict()
-try:
+entries = {}
+
+
+def run_entrypoints():
     import entrypoints
-    entries = entrypoints.get_group_named("numcodecs.codecs")
-except ImportError:
-    entries = {}
+    entries.clear()
+    entries.update(entrypoints.get_group_named("numcodecs.codecs"))
+
+
+try:
+    run_entrypoints()
+except ImportError:  # pragma: no cover
+    # marked "no cover" since we will include entrypoints in test env
+    pass
 
 
 def get_codec(config):
@@ -37,6 +46,7 @@ def get_codec(config):
     if cls is None:
         if codec_id in entries:
             cls = entries[codec_id].load()
+            register_codec(cls, codec_id=codec_id)
     if cls:
         return cls.from_config(config)
     raise ValueError('codec not available: %r' % codec_id)

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -14,7 +14,7 @@ def run_entrypoints():
 
 try:
     run_entrypoints()
-except ImportError:  # pragma: no cover
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
     # marked "no cover" since we will include entrypoints in test env
     pass
 

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -4,7 +4,6 @@ applications to dynamically register and look-up codec classes."""
 
 codec_registry = dict()
 try:
-    raise ImportError
     import entrypoints
     entries = entrypoints.get_group_named("numcodecs.codecs")
 except ImportError:

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -1,7 +1,8 @@
 """The registry module provides some simple convenience functions to enable
 applications to dynamically register and look-up codec classes."""
+import logging
 
-
+logger = logging.getLogger("numcodecs")
 codec_registry = dict()
 entries = {}
 
@@ -45,6 +46,7 @@ def get_codec(config):
     cls = codec_registry.get(codec_id)
     if cls is None:
         if codec_id in entries:
+            logger.debug("Auto loading codec '%s' from entrypoint", codec_id)
             cls = entries[codec_id].load()
             register_codec(cls, codec_id=codec_id)
     if cls:
@@ -68,4 +70,5 @@ def register_codec(cls, codec_id=None):
     """
     if codec_id is None:
         codec_id = cls.codec_id
+    logger.debug("Registering codec '%s'", codec_id)
     codec_registry[codec_id] = cls

--- a/numcodecs/tests/package_with_entrypoint-0.1.dist-info/entry_points.txt
+++ b/numcodecs/tests/package_with_entrypoint-0.1.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[numcodecs.codecs]
+test = package_with_entrypoint:TestCodec

--- a/numcodecs/tests/package_with_entrypoint/__init__.py
+++ b/numcodecs/tests/package_with_entrypoint/__init__.py
@@ -5,8 +5,8 @@ class TestCodec(Codec):
 
     codec_id = "test"
 
-    def encode(self, buf):
+    def encode(self, buf):  # pragma: no cover
         pass
 
-    def decode(self, buf, out=None):
+    def decode(self, buf, out=None):  # pragma: no cover
         pass

--- a/numcodecs/tests/package_with_entrypoint/__init__.py
+++ b/numcodecs/tests/package_with_entrypoint/__init__.py
@@ -1,0 +1,12 @@
+from numcodecs.abc import Codec
+
+
+class TestCodec(Codec):
+
+    codec_id = "test"
+
+    def encode(self, buf):
+        pass
+
+    def decode(self, buf, out=None):
+        pass

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -1,0 +1,24 @@
+import os.path
+import sys
+
+import pytest
+
+import numcodecs.registry
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+@pytest.fixture()
+def set_path():
+    sys.path.append(here)
+    numcodecs.registry.run_entrypoints()
+    yield
+    sys.path.remove(here)
+    numcodecs.registry.run_entrypoints()
+    numcodecs.registry.codec_registry.pop("test")
+
+
+def test_entrypoint_codec(set_path):
+    cls = numcodecs.registry.get_codec({"id": "test"})
+    assert cls.codec_id == "test"

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -7,6 +7,7 @@ import numcodecs.registry
 
 
 here = os.path.abspath(os.path.dirname(__file__))
+pytest.importorskip("entrypoints")
 
 
 @pytest.fixture()

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 coverage
 coveralls
+entrypoints
 flake8
 pytest
 pytest-cov


### PR DESCRIPTION
Allows for packages to list codecs in entrypoints, so that the package in question doesn't need to be imported in before the codec can be usable.

Notes:
- the long list of try import/register in `numcodecs/__init__` could be avoided by this.
- we'll need a way to list all the available codecs
- How.should this be documented?

Fixes #290

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] `tox -e py39` passes locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] `tox -e docs` passes locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Coveralls passes)
