### PR TITLE
chore: bump cibuildwheel version, use action

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-18.04, ubuntu-20.04]
 
     steps:

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
 
       - uses: pypa/cibuildwheel@v2.3.1
-        
+
       - uses: actions/upload-artifact@v1
         with:
           name: wheels


### PR DESCRIPTION
Followup to #308. General recommendations:

* There should be a pyproject.toml. Then these cibuildwheel settings can be put there. You also need the lines here if you add one: https://scikit-hep.org/developer/packaging#pep-517518-support-high-priority - FYI, `setup_requires` is deprecated and produces a warning.
* Checkout and upload/download actions are using v1. You should use v2.
* You can set up a dependabot update following https://cibuildwheel.readthedocs.io/en/stable/faq/#automatic-updates
* This will also enable musllinux wheels, can be manually skipped if you don't want to ship for musl
* This will use manylinux2014 as default for all wheels - can be set lower if you need manylinux2010 still (ideally in TOML, so you can set <3.9 as 2010 and 3.10+ as 2014 using overrides). Looks like manylinux2010 is going away, though: https://github.com/pypa/manylinux/issues/1281. Mostly 3.6 & 3.7 are affected. Dropping before that happens is one solution. ;)
* It doesn't look like you are building for M1, see https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon (scroll down a little for an example). There's also guides to build for emulated linux architectures.

I'd also recommend testing on 3.10. You could add 3.10 and drop 3.6, if you want to keep to 4 versions (or non-EOL) versions supported.