### PR TITLE
Fix macOS Python 3.10

### DIFF
--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -24,6 +24,13 @@ jobs:
         env:
             ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
+      - name: Show info about `base` environment
+        shell: "bash -l {0}"
+        run: |
+          conda info
+          conda config --show-sources
+          conda list --show-channel-urls
+
       - name: Set up env
         shell: "bash -l {0}"
         run: |
@@ -32,6 +39,11 @@ jobs:
           which pip
           pip install -r requirements_test.txt -r requirements.txt
           conda env export
+
+      - name: Show info about `env` environment
+        shell: "bash -l {0}"
+        run: |
+          conda list --show-channel-urls -n env
 
       - name: Install numcodecs
         shell: "bash -l {0}"

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up env
         shell: "bash -l {0}"
         run: |
-          conda create -n env python==${{matrix.python-version}} wheel pip compilers 'clang>=12.0.1'
+          conda create -n env python=${{matrix.python-version}} wheel pip compilers 'clang>=12.0.1'
           conda activate env
           which pip
           pip install -r requirements_test.txt -r requirements.txt

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up env
         shell: "bash -l {0}"
         run: |
-          conda create -n env python==${{matrix.python-version}} wheel pip compilers
+          conda create -n env python==${{matrix.python-version}} wheel pip compilers 'clang>=12.0.1'
           conda activate env
           which pip
           pip install -r requirements_test.txt -r requirements.txt

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up env
         shell: "bash -l {0}"
         run: |
-          conda create -n env python==${{matrix.python-version}} wheel pip compilers
+          conda create -n env python=${{matrix.python-version}} wheel pip compilers
           conda activate env
           which pip
           pip install -r requirements_test.txt -r requirements.txt


### PR DESCRIPTION
For some reason we pick up `clang` version `12.0.0` only in the Python 3.10 job, which has problems with TAPI (hence the CI issues we have been seeing). These issues are not present with `clang` version `12.0.1`+ (hence why the other Python jobs work). So here we require `clang` version `12.0.1`+ when installing compilers to fix CI.

Edit: Also included a bit more debug info in CI to aid with issue templates that Conda & conda-forge use

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
