### PR TITLE
Trim wheel builds

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       CIBW_TEST_COMMAND: pytest --pyargs numcodecs
       CIBW_TEST_REQUIRES: pytest
-      CIBW_SKIP: "pp* cp36-*"
+      CIBW_SKIP: "pp* cp36-* *win32 *_i686"
       CIBW_ENVIRONMENT: "DISABLE_NUMCODECS_AVX2=1"
       CIBW_ENVIRONMENT_MACOS: 'MACOSX_DEPLOYMENT_TARGET=10.9 DISABLE_NUMCODECS_AVX2=1 CFLAGS="$CFLAGS -Wno-implicit-function-declaration"'
 

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       CIBW_TEST_COMMAND: pytest --pyargs numcodecs
       CIBW_TEST_REQUIRES: pytest
-      CIBW_SKIP: "pp* cp36-* *-musllinux_* *win32 *_i686"
+      CIBW_SKIP: "pp* cp36-* *-musllinux_* *win32 *_i686 *_s390x"
       CIBW_ENVIRONMENT: "DISABLE_NUMCODECS_AVX2=1"
       CIBW_ENVIRONMENT_MACOS: 'MACOSX_DEPLOYMENT_TARGET=10.9 DISABLE_NUMCODECS_AVX2=1 CFLAGS="$CFLAGS -Wno-implicit-function-declaration"'
 

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       CIBW_TEST_COMMAND: pytest --pyargs numcodecs
       CIBW_TEST_REQUIRES: pytest
-      CIBW_SKIP: "pp* cp36-* *win32 *_i686"
+      CIBW_SKIP: "pp* cp36-* *-musllinux_* *win32 *_i686"
       CIBW_ENVIRONMENT: "DISABLE_NUMCODECS_AVX2=1"
       CIBW_ENVIRONMENT_MACOS: 'MACOSX_DEPLOYMENT_TARGET=10.9 DISABLE_NUMCODECS_AVX2=1 CFLAGS="$CFLAGS -Wno-implicit-function-declaration"'
 


### PR DESCRIPTION
Partially addresses issue ( https://github.com/zarr-developers/numcodecs/issues/312 )

The wheel build matrix is taking [2.5hrs to go through]( https://github.com/zarr-developers/numcodecs/runs/5668831517?check_suite_focus=true ). Some of these builds are for novel architectures or deployments that are not really tested. Trim the build matrix to a more reasonable set of build to get the build time more manageable.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
