### PR TITLE
Drop `fastparquet` benchmark

### DIFF
--- a/notebooks/benchmark_vlen.ipynb
+++ b/notebooks/benchmark_vlen.ipynb
@@ -42,37 +42,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import fastparquet\n",
-    "\n",
-    "\n",
-    "class FastParquetCodec(numcodecs.abc.Codec):\n",
-    "    \"\"\"Hacked codec using fastparquet utf8 encoding, for benchmarking purposes only.\"\"\"\n",
-    "    \n",
-    "    codec_id = 'xxx-fastparquet'\n",
-    "    \n",
-    "    def encode(self, buf):\n",
-    "        buf = np.asanyarray(buf)\n",
-    "        n = buf.size\n",
-    "        ba = fastparquet.speedups.array_encode_utf8(buf)\n",
-    "        enc = fastparquet.speedups.pack_byte_array(ba.tolist())\n",
-    "        return n, enc  # hack for now, return n\n",
-    "    \n",
-    "    def decode(self, data, out=None):\n",
-    "        n, enc = data\n",
-    "        ba = fastparquet.speedups.unpack_byte_array(enc, n)\n",
-    "        dec = fastparquet.speedups.array_decode_utf8(np.array(ba, dtype=object))\n",
-    "        if out is not None:\n",
-    "            out[:] = dec\n",
-    "            return out\n",
-    "        return dec"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "zstd1 = numcodecs.Zstd(1)\n",
     "zstd5 = numcodecs.Zstd(5)\n",
     "zstd9 = numcodecs.Zstd(9)\n",
@@ -85,17 +54,15 @@
     "    enc = codec.encode(a)\n",
     "    print('decode')\n",
     "    %timeit codec.decode(enc)\n",
-    "    if isinstance(codec, FastParquetCodec):\n",
-    "        enc = enc[1]  # hack\n",
     "    print('size         : {:,}'.format(len(enc)))\n",
     "    print('size (zstd 1): {:,}'.format(len(zstd1.encode(enc))))\n",
     "    print('size (zstd 5): {:,}'.format(len(zstd5.encode(enc))))\n",
-    "    print('size (zstd 9): {:,}'.format(len(zstd9.encode(enc))))\n"
+    "    print('size (zstd 9): {:,}'.format(len(zstd9.encode(enc))))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,8 +71,7 @@
     "json_codec = numcodecs.JSON()\n",
     "pickle_codec = numcodecs.Pickle()\n",
     "cat_codec = numcodecs.Categorize(greetings, dtype=object, astype='u1')\n",
-    "vlen_codec = numcodecs.VLenUTF8()\n",
-    "fp_codec = FastParquetCodec()"
+    "vlen_codec = numcodecs.VLenUTF8()"
    ]
   },
   {
@@ -117,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -127,7 +93,7 @@
        "       'Servus Woid!', 'เฮลโลเวิลด์', 'Zdravo svete!'], dtype=object)"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -140,6 +106,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 109 ms, sys: 30.9 ms, total: 140 ms\n",
+      "Wall time: 143 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%time enc = vlen_codec.encode(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
    "outputs": [
@@ -147,13 +131,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 104 ms, sys: 32.9 ms, total: 137 ms\n",
-      "Wall time: 137 ms\n"
+      "CPU times: user 162 ms, sys: 25.1 ms, total: 187 ms\n",
+      "Wall time: 185 ms\n"
      ]
     }
    ],
    "source": [
-    "%time enc = vlen_codec.encode(data)"
+    "%time dec = vlen_codec.decode(enc)"
    ]
   },
   {
@@ -165,29 +149,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 172 ms, sys: 30.1 ms, total: 202 ms\n",
-      "Wall time: 202 ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "%time dec = vlen_codec.decode(enc)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "MsgPack(raw=False, use_bin_type=True, use_single_float=False)\n",
       "encode\n",
-      "83.5 ms ± 3.15 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "78.6 ms ± 9.27 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "decode\n",
-      "288 ms ± 6.58 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "265 ms ± 33.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
       "size         : 18,913,397\n",
       "size (zstd 1): 1,529,314\n",
       "size (zstd 5): 1,405,819\n",
@@ -201,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -212,9 +178,9 @@
       "     indent=None, separators=(',', ':'), skipkeys=False, sort_keys=True,\n",
       "     strict=True)\n",
       "encode\n",
-      "291 ms ± 6.69 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "252 ms ± 5.51 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
       "decode\n",
-      "420 ms ± 11.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "396 ms ± 45.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
       "size         : 33,322,605\n",
       "size (zstd 1): 1,840,791\n",
       "size (zstd 5): 1,675,175\n",
@@ -228,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -237,9 +203,9 @@
      "text": [
       "Pickle(protocol=5)\n",
       "encode\n",
-      "285 ms ± 7.03 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "277 ms ± 37.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
       "decode\n",
-      "273 ms ± 6.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "258 ms ± 37.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
       "size         : 20,835,273\n",
       "size (zstd 1): 1,565,100\n",
       "size (zstd 5): 1,435,771\n",
@@ -253,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -262,9 +228,9 @@
      "text": [
       "Categorize(dtype='|O', astype='|u1', labels=['¡Hola mundo!', 'Hej Världen!', 'Servus Woid!', ...])\n",
       "encode\n",
-      "263 ms ± 10.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "274 ms ± 21.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
       "decode\n",
-      "46.7 ms ± 2.79 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "46.3 ms ± 4.54 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "size         : 1,000,000\n",
       "size (zstd 1): 458,196\n",
       "size (zstd 5): 490,680\n",
@@ -278,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -287,9 +253,9 @@
      "text": [
       "VLenUTF8()\n",
       "encode\n",
-      "125 ms ± 14.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "107 ms ± 10.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "decode\n",
-      "234 ms ± 18.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "184 ms ± 2.66 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "size         : 21,830,275\n",
       "size (zstd 1): 1,762,783\n",
       "size (zstd 5): 1,546,616\n",
@@ -302,31 +268,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "FastParquetCodec()\n",
-      "encode\n",
-      "118 ms ± 3.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "decode\n",
-      "325 ms ± 31.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
-      "size         : 21,830,271\n",
-      "size (zstd 1): 1,762,787\n",
-      "size (zstd 5): 1,546,612\n",
-      "size (zstd 9): 1,216,426\n"
-     ]
-    }
-   ],
-   "source": [
-    "benchmark_codec(fp_codec, data)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -335,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,18 +286,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(1101020,\n",
-       " array(['Most', 'top', 'magazine', 'bed', 'successful.', 'Center',\n",
-       "        'exactly', 'and', 'hour', 'wide'], dtype=object))"
+       "(1102008,\n",
+       " array(['Ahead', 'everybody', 'important', 'indeed.', 'White', 'look',\n",
+       "        'than', 'environment', 'anyone.', 'Order'], dtype=object))"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -368,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -377,18 +318,70 @@
      "text": [
       "MsgPack(raw=False, use_bin_type=True, use_single_float=False)\n",
       "encode\n",
-      "76.9 ms ± 602 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "76.7 ms ± 996 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "decode\n",
-      "191 ms ± 21.7 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "size         : 7,399,529\n",
-      "size (zstd 1): 3,308,650\n",
-      "size (zstd 5): 2,706,469\n",
-      "size (zstd 9): 2,697,930\n"
+      "173 ms ± 7.82 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "size         : 7,405,616\n",
+      "size (zstd 1): 3,312,068\n",
+      "size (zstd 5): 2,708,195\n",
+      "size (zstd 9): 2,700,345\n"
      ]
     }
    ],
    "source": [
     "benchmark_codec(msgpack_codec, data2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JSON(encoding='utf-8', allow_nan=True, check_circular=True, ensure_ascii=True,\n",
+      "     indent=None, separators=(',', ':'), skipkeys=False, sort_keys=True,\n",
+      "     strict=True)\n",
+      "encode\n",
+      "183 ms ± 14.2 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "decode\n",
+      "189 ms ± 5.59 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "size         : 9,609,634\n",
+      "size (zstd 1): 2,897,941\n",
+      "size (zstd 5): 2,715,484\n",
+      "size (zstd 9): 2,682,781\n"
+     ]
+    }
+   ],
+   "source": [
+    "benchmark_codec(json_codec, data2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pickle(protocol=5)\n",
+      "encode\n",
+      "230 ms ± 3.38 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "decode\n",
+      "164 ms ± 8.68 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "size         : 9,615,186\n",
+      "size (zstd 1): 3,054,991\n",
+      "size (zstd 5): 2,756,213\n",
+      "size (zstd 9): 2,830,899\n"
+     ]
+    }
+   ],
+   "source": [
+    "benchmark_codec(pickle_codec, data2)"
    ]
   },
   {
@@ -400,97 +393,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JSON(encoding='utf-8', allow_nan=True, check_circular=True, ensure_ascii=True,\n",
-      "     indent=None, separators=(',', ':'), skipkeys=False, sort_keys=True,\n",
-      "     strict=True)\n",
-      "encode\n",
-      "226 ms ± 18.7 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "decode\n",
-      "271 ms ± 29.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
-      "size         : 9,601,571\n",
-      "size (zstd 1): 2,895,764\n",
-      "size (zstd 5): 2,713,287\n",
-      "size (zstd 9): 2,681,954\n"
-     ]
-    }
-   ],
-   "source": [
-    "benchmark_codec(json_codec, data2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Pickle(protocol=5)\n",
-      "encode\n",
-      "342 ms ± 36 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
-      "decode\n",
-      "193 ms ± 6.01 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "size         : 9,607,048\n",
-      "size (zstd 1): 3,052,431\n",
-      "size (zstd 5): 2,754,370\n",
-      "size (zstd 9): 2,828,895\n"
-     ]
-    }
-   ],
-   "source": [
-    "benchmark_codec(pickle_codec, data2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "VLenUTF8()\n",
       "encode\n",
-      "116 ms ± 6.88 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "111 ms ± 4.91 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "decode\n",
-      "140 ms ± 13.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "size         : 10,702,579\n",
-      "size (zstd 1): 3,638,377\n",
-      "size (zstd 5): 3,458,719\n",
-      "size (zstd 9): 3,023,123\n"
+      "116 ms ± 3.35 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "size         : 10,711,630\n",
+      "size (zstd 1): 3,641,192\n",
+      "size (zstd 5): 3,461,415\n",
+      "size (zstd 9): 3,025,742\n"
      ]
     }
    ],
    "source": [
     "benchmark_codec(vlen_codec, data2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "FastParquetCodec()\n",
-      "encode\n",
-      "126 ms ± 8.51 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
-      "decode\n",
-      "211 ms ± 14.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
-      "size         : 10,702,575\n",
-      "size (zstd 1): 3,638,601\n",
-      "size (zstd 5): 3,458,675\n",
-      "size (zstd 9): 3,022,583\n"
-     ]
-    }
-   ],
-   "source": [
-    "benchmark_codec(fp_codec, data2)"
    ]
   },
   {
@@ -502,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -523,7 +439,7 @@
        "       b'Zdravo svete!'], dtype=object)"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -537,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -549,7 +465,7 @@
        "       b'Zdravo svete!'], dtype=object)"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -560,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -569,9 +485,9 @@
      "text": [
       "Pickle(protocol=5)\n",
       "encode\n",
-      "253 ms ± 9.93 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "231 ms ± 13.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
       "decode\n",
-      "111 ms ± 1.78 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "108 ms ± 6.25 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "size         : 20,835,273\n",
       "size (zstd 1): 1,565,112\n",
       "size (zstd 5): 1,435,770\n",
@@ -585,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -594,9 +510,9 @@
      "text": [
       "VLenBytes()\n",
       "encode\n",
-      "32.3 ms ± 418 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "33.7 ms ± 3.31 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "decode\n",
-      "71.5 ms ± 1.72 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "65.4 ms ± 1.46 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "size         : 21,830,275\n",
       "size (zstd 1): 1,762,783\n",
       "size (zstd 5): 1,546,616\n",
@@ -617,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -631,7 +547,7 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -645,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -668,7 +584,7 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -679,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -688,9 +604,9 @@
      "text": [
       "VLenArray(dtype='<i4')\n",
       "encode\n",
-      "27.5 ms ± 1.15 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "24.8 ms ± 1.48 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "decode\n",
-      "58.2 ms ± 1.31 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "53.5 ms ± 842 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "size         : 4,195,540\n",
       "size (zstd 1): 1,299,769\n",
       "size (zstd 5): 1,119,369\n",
@@ -704,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -713,9 +629,9 @@
      "text": [
       "Pickle(protocol=5)\n",
       "encode\n",
-      "313 ms ± 8.21 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "280 ms ± 13 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
       "decode\n",
-      "141 ms ± 3.63 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "130 ms ± 7.01 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
       "size         : 6,296,822\n",
       "size (zstd 1): 1,619,421\n",
       "size (zstd 5): 1,507,086\n",


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/numcodecs/issues/319

The `array_decode_utf8` function has gone away in `fastparquet` version `0.6.0`. So the `FastParquetCodec` created here no longer works. There doesn't seem to be a good alternative function to use in its place. Given this, go ahead and drop `fastparquet` from the benchmark.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
