### PR TITLE
Move `master` to `main`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,14 +7,14 @@ codecs for use in data storage and communication applications.
 .. image:: https://readthedocs.org/projects/numcodecs/badge/?version=latest
     :target: http://numcodecs.readthedocs.io/en/latest/?badge=latest
 
-.. image:: https://github.com/zarr-developers/numcodecs/workflows/Linux%20CI/badge.svg?branch=master
+.. image:: https://github.com/zarr-developers/numcodecs/workflows/Linux%20CI/badge.svg?branch=main
     :target: https://github.com/zarr-developers/numcodecs/actions?query=workflow%3A%22Linux+CI%22
 
-.. image:: https://github.com/zarr-developers/numcodecs/workflows/OSX%20CI/badge.svg?branch=master
+.. image:: https://github.com/zarr-developers/numcodecs/workflows/OSX%20CI/badge.svg?branch=main
     :target: https://github.com/zarr-developers/numcodecs/actions?query=workflow%3A%22OSX+CI%22
 
-.. image:: https://github.com/zarr-developers/numcodecs/workflows/Wheels/badge.svg?branch=master
+.. image:: https://github.com/zarr-developers/numcodecs/workflows/Wheels/badge.svg?branch=main
     :target: https://github.com/zarr-developers/numcodecs/actions?query=workflow%3AWheels
 
-.. image:: https://coveralls.io/repos/github/zarr-developers/numcodecs/badge.svg?branch=master
-    :target: https://coveralls.io/github/zarr-developers/numcodecs?branch=master
+.. image:: https://coveralls.io/repos/github/zarr-developers/numcodecs/badge.svg?branch=main
+    :target: https://coveralls.io/github/zarr-developers/numcodecs?branch=main

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,8 +65,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'numcodecs'
@@ -249,7 +249,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'numcodecs.tex', 'numcodecs Documentation',
+    (main_doc, 'numcodecs.tex', 'numcodecs Documentation',
      'Alistair Miles', 'manual'),
 ]
 
@@ -279,7 +279,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'numcodecs', 'numcodecs Documentation',
+    (main_doc, 'numcodecs', 'numcodecs Documentation',
      [author], 1)
 ]
 
@@ -293,7 +293,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'numcodecs', 'numcodecs Documentation',
+    (main_doc, 'numcodecs', 'numcodecs Documentation',
      author, 'numcodecs', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -183,7 +183,7 @@ Documentation
 ~~~~~~~~~~~~~
 
 Docstrings for user-facing classes and functions should follow the `numpydoc
-<https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_ standard,
+<https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ standard,
 including sections for Parameters and Examples. All examples will be run as doctests
 under Python 3.9.
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -108,25 +108,25 @@ report the bug or propose the feature you'd like to add.
 It's best to create a new, separate branch for each piece of work you want to do. E.g.::
 
     git fetch upstream
-    git checkout -b shiny-new-feature upstream/master
+    git checkout -b shiny-new-feature upstream/main
 
 This changes your working directory to the 'shiny-new-feature' branch. Keep any changes in
 this branch specific to one bug or feature so it is clear what the branch brings to
 NumCodecs.
 
 To update this branch with latest code from NumCodecs, you can retrieve the changes from
-the master branch and perform a rebase::
+the main branch and perform a rebase::
 
     git fetch upstream
-    git rebase upstream/master
+    git rebase upstream/main
 
-This will replay your commits on top of the latest NumCodecs git master. If this leads to
+This will replay your commits on top of the latest NumCodecs git main. If this leads to
 merge conflicts, these need to be resolved before submitting a pull request.
-Alternatively, you can merge the changes in from upstream/master instead of rebasing,
+Alternatively, you can merge the changes in from upstream/main instead of rebasing,
 which can be simpler::
 
     git fetch upstream
-    git merge upstream/master
+    git merge upstream/main
 
 Again, any conflicts need to be resolved before submitting a pull request.
 
@@ -213,7 +213,7 @@ one core developers before being merged. Ideally, pull requests submitted by a c
 should be reviewed and approved by at least one other core developers before being merged.
 
 Pull requests should not be merged until all CI checks have passed (Travis, AppVeyor,
-Coveralls) against code that has had the latest master merged in.
+Coveralls) against code that has had the latest main merged in.
 
 Compatibility and versioning policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -290,9 +290,9 @@ compatibility in some way.
 Release procedure
 ~~~~~~~~~~~~~~~~~
 
-Checkout and update the master branch::
+Checkout and update the main branch::
 
-    $ git checkout master
+    $ git checkout main
     $ git pull
 
 Verify all tests pass on all supported Python versions, and docs build::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. numcodecs documentation master file, created by
+.. numcodecs documentation main file, created by
    sphinx-quickstart on Mon May  2 21:40:09 2016.
 
 


### PR DESCRIPTION
Partially addresses ( https://github.com/zarr-developers/community/issues/44 )

Moves all branch references from `master` to `main`. These are self-referential links (other Numcodecs things like CI).

Also updates terminology in doc generating code similarly and 3rd party links.

Other GitHub Actions are left alone as they haven't made the move yet.

xref: https://github.com/pypa/gh-action-pypi-publish/issues/83
xref: https://github.com/conda-incubator/setup-miniconda/issues/231

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
