### PR TITLE
Specify `language` as `'en'` instead of `None`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,7 @@ release = numcodecs.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Needed for Sphinx 5 compatibility. Should fix [warning on CI]( https://github.com/zarr-developers/numcodecs/runs/6993269158?check_suite_focus=true ).

```
Warning, treated as error:
[88](https://github.com/zarr-developers/numcodecs/runs/6993269158?check_suite_focus=true#step:8:89)
Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).
```

xref: https://github.com/sphinx-doc/sphinx/pull/10481

<hr>

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
