### PR TITLE
Add LGTM.com configuration file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,17 @@
+---
+# This file contains configuration for the LGTM tool: https://lgtm.com/
+# The numcodecs repository is continuously scanned by the LGTM tool for
+# any security and/or code vulnerabilities. You can find the alerts here:
+# https://lgtm.com/projects/g/zarr-developers/numcodecs
+
+extraction:
+  python:
+    index:
+      exclude: cpuinfo.py
+
+path_classifiers:
+  test:
+    - numcodecs/tests
+
+queries:
+  - exclude: py/clear-text-logging-sensitive-data

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -24,6 +24,9 @@ Maintenance
 * Remove trailing spaces and empty lines.
   By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`341`.
 
+* Add LGTM.com configuration file
+  By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`337`.
+
 .. _release_0.10.0:
 
 0.10.0


### PR DESCRIPTION
The YAML configuration file for the LGTM static analysis tool can be either `lgtm.yml` or `.lgtm.yml`:
	https://lgtm.com/help/lgtm/lgtm.yml-configuration-file

There is no need to integrate the LGTM tool in CI, as LGTM appears to be running on all repositories it has been run on once. The results currently appear here:
	https://lgtm.com/projects/g/zarr-developers/numcodecs

Exclude vendored `cpuinfo.py` file from analysis.

See similar merge request https://github.com/zarr-developers/zarr-python/pull/909.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [X] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
