### PR TITLE
Update supported versions of Python in tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 TODO:
 
 - [ ] Unit tests and/or doctests in docstrings
-- [ ] `tox -e py39` passes locally
+- [ ] `tox -e py310` passes locally
 - [ ] Docstrings and API docs for any new/modified user-facing classes and functions
 - [ ] Changes documented in docs/release.rst
 - [ ] `tox -e docs` passes locally

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -17,6 +17,10 @@ Maintenance
 * Fix spelling.
   By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`336`.
 
+* Drop Python 3.6 from tests
+  By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`,
+  :issue:`338`, :issue:`339`.
+
 * Remove trailing spaces and empty lines.
   By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`341`.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,28 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
+# Tox (https://tox.wiki/) is a tool for running tests in multiple virtualenvs.
+# This configuration file will run the test suite on supported python versions.
+# To use it, "pip install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39, docs
+envlist = py37, py38, py39, py310, docs
 
 [testenv]
 setenv =
     PYTHONHASHSEED = 42
     # hooks for coverage exclusions based on Python major version
-    py36,py37,py38,py39: PY_MAJOR_VERSION = py3
+    py37,py38,py39,py310: PY_MAJOR_VERSION = py3
 commands =
     python setup.py build_ext --inplace
-    py36,py37,py38: pytest -v --cov=numcodecs numcodecs
-    py39: pytest -v --cov=numcodecs --doctest-modules --doctest-glob=*.pyx numcodecs
+    py37,py38,py39: pytest -v --cov=numcodecs numcodecs
+    py310: pytest -v --cov=numcodecs --doctest-modules --doctest-glob=*.pyx numcodecs
     coverage report -m
-    py39: flake8 numcodecs
+    py310: flake8 numcodecs
     pip freeze
 deps =
     -rrequirements_dev.txt
     -rrequirements_test.txt
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.10
 changedir = docs
 deps =
     -rrequirements_rtfd.txt


### PR DESCRIPTION
Fixes #338.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py39` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Coveralls passes)
