### PR TITLE
Register BitRound (fix #346)

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -11,6 +11,17 @@ Release notes
     Unreleased
     ----------
 
+.. _release_0.10.2:
+
+0.10.2
+------
+
+Fix
+~~~
+
+* Add BitRound (0.10.0) to registry.
+  By :user:`Josh Moore <joshmoore>`, :issue:`342`.
+
 .. _release_0.10.1:
 
 0.10.1

--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -100,6 +100,9 @@ register_codec(Base64)
 from numcodecs.shuffle import Shuffle
 register_codec(Shuffle)
 
+from numcodecs.bitround import BitRound
+register_codec(BitRound)
+
 try:
     from numcodecs.msgpacks import MsgPack
     register_codec(MsgPack)


### PR DESCRIPTION
#299 was missing the registration of the class itself. We likely need a test to detect all classes that _weren't_ registered.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py310` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
