### PR TITLE
Test all Codec classes (see #347)

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,10 +6,16 @@ Release notes
     # to document your changes. On releases it will be
     # re-indented so that it does not show up in the notes.
 
-    .. _unreleased:
+.. _unreleased:
 
-    Unreleased
-    ----------
+Unreleased
+----------
+
+Maintenance
+~~~~~~~~~~~
+
+* Add tests for all registry classes.
+  By :user:`Josh Moore <joshmoore>`, :issue:`349`.
 
 .. _release_0.10.2:
 

--- a/numcodecs/tests/test_registry.py
+++ b/numcodecs/tests/test_registry.py
@@ -1,6 +1,9 @@
 import pytest
 
+import importlib
+import inspect
 
+import numcodecs
 from numcodecs.registry import get_codec
 
 
@@ -15,3 +18,24 @@ def test_get_codec_argument():
     before = dict(arg)
     get_codec(arg)
     assert before == arg
+
+
+def test_all_classes_registered():
+    """
+    find all Codec subclasses in this repository and check that they
+    have been registered.
+
+    see #346 for more info
+    """
+    missing = set()
+    for name, submod in inspect.getmembers(numcodecs, inspect.ismodule):
+            for name, obj in inspect.getmembers(submod):
+                if inspect.isclass(obj):
+                    if issubclass(obj, numcodecs.abc.Codec):
+                        if obj.codec_id not in numcodecs.registry.codec_registry:
+                            missing.add(obj.codec_id)
+
+    # remove `None``
+    missing.remove(None)
+    if missing:
+        raise Exception(f"these codecs are missing: {missing}")

--- a/numcodecs/tests/test_registry.py
+++ b/numcodecs/tests/test_registry.py
@@ -1,6 +1,5 @@
 import pytest
 
-import importlib
 import inspect
 
 import numcodecs

--- a/numcodecs/tests/test_registry.py
+++ b/numcodecs/tests/test_registry.py
@@ -29,11 +29,11 @@ def test_all_classes_registered():
     """
     missing = set()
     for name, submod in inspect.getmembers(numcodecs, inspect.ismodule):
-            for name, obj in inspect.getmembers(submod):
-                if inspect.isclass(obj):
-                    if issubclass(obj, numcodecs.abc.Codec):
-                        if obj.codec_id not in numcodecs.registry.codec_registry:
-                            missing.add(obj.codec_id)
+        for name, obj in inspect.getmembers(submod):
+            if inspect.isclass(obj):
+                if issubclass(obj, numcodecs.abc.Codec):
+                    if obj.codec_id not in numcodecs.registry.codec_registry:
+                        missing.add(obj.codec_id)
 
     # remove `None``
     missing.remove(None)


### PR DESCRIPTION
find all Codec subclasses in this repository and check that they have been registered.

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] `tox -e py310` passes locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] `tox -e docs` passes locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Coveralls passes)
