### PR TITLE
ci: ubuntu-20.04 -> ubuntu-latest

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Right now, `ubuntu-20.04` and `ubuntu-latest` are documented to be equivalent.

At some point, I suppose ubuntu-latest will automatically switch to new Ubuntu releases, which should ease maintenance (?)

Addresses #340.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py310` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
