### PR TITLE
Overlapping exceptions

### DIFF
--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -15,7 +15,7 @@ def run_entrypoints():
 
 try:
     run_entrypoints()
-except (ImportError, ModuleNotFoundError):  # pragma: no cover
+except ImportError:  # pragma: no cover
     # marked "no cover" since we will include entrypoints in test env
     pass
 


### PR DESCRIPTION
[Exceptions are overlapping PYL-W0714](https://deepsource.io/gh/DimitriPapadopoulos/numcodecs/issue/PYL-W0714/occurrences)

> `ImportError` is an ancestor class of `ModuleNotFoundError`

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py310` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
