### PR TITLE
Document that variable `checksum` must be overridden

### DIFF
--- a/numcodecs/checksum32.py
+++ b/numcodecs/checksum32.py
@@ -10,6 +10,7 @@ from .compat import ensure_contiguous_ndarray, ndarray_copy
 
 class Checksum32(Codec):
 
+    # override in sub-class
     checksum = None
 
     def encode(self, buf):


### PR DESCRIPTION
Base classe `Codec` documents variable `codec_id` in the same way:
https://github.com/zarr-developers/numcodecs/blob/a3e05fd36f2cd7a2c903c4d5d9f787961a7a5905/numcodecs/abc.py#L35-L40

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py310` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
