### PR TITLE
Appending to dictionary immediately following its definition

### DIFF
--- a/numcodecs/astype.py
+++ b/numcodecs/astype.py
@@ -68,11 +68,11 @@ class AsType(Codec):
         return out
 
     def get_config(self):
-        config = {}
-        config['id'] = self.codec_id
-        config['encode_dtype'] = self.encode_dtype.str
-        config['decode_dtype'] = self.decode_dtype.str
-        return config
+        return {
+            'id': self.codec_id,
+            'encode_dtype': self.encode_dtype.str,
+            'decode_dtype': self.decode_dtype.str,
+        }
 
     def __repr__(self):
         return (


### PR DESCRIPTION
Fix DeepSource.io alert:
>	Instead of adding items to a dictionary just after creation,
>	it should be refactored to add those items into the dict
>	definition itself.

See:
https://deepsource.io/gh/DimitriPapadopoulos/numcodecs/issue/PY-W0072

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py310` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [X] Test coverage to 100% (Coveralls passes)
