### PR TITLE
Update developer installation guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -75,9 +75,9 @@ The NumCodecs source code is hosted on GitHub at the following location:
 You will need your own fork to work on the code. Go to the link above and hit
 the "Fork" button. Then clone your fork to your local machine::
 
-    $ git clone --recursive https://github.com/your-user-name/numcodecs.git
+    $ git clone --recursive git@github.com:your-user-name/numcodecs.git
     $ cd numcodecs
-    $ git remote add upstream https://github.com/zarr-developers/numcodecs.git
+    $ git remote add upstream git@github.com:zarr-developers/numcodecs.git
 
 Creating a development environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -75,7 +75,14 @@ The NumCodecs source code is hosted on GitHub at the following location:
 You will need your own fork to work on the code. Go to the link above and hit
 the "Fork" button. Then clone your fork to your local machine::
 
-    $ git clone --recursive git@github.com:your-user-name/numcodecs.git
+    $ git clone --recursive git@github.com:your-user-name/numcodecs.git  # with ``ssh``
+    
+    or
+
+    $ git clone --recursive https://github.com/your-user-name/numcodecs.git  # with ``https``
+
+    Then `cd` into the clone:
+
     $ cd numcodecs
     $ git remote add upstream git@github.com:zarr-developers/numcodecs.git
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -84,7 +84,7 @@ or::
 Then ``cd`` into the clone and add the ``upstream`` remote::
 
     $ cd numcodecs
-    $ git remote add upstream git@github.com:zarr-developers/numcodecs.git  # or use ``https``
+    $ git remote add upstream https://github.com/zarr-developers/numcodecs.git
 
 Creating a development environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -75,9 +75,9 @@ The NumCodecs source code is hosted on GitHub at the following location:
 You will need your own fork to work on the code. Go to the link above and hit
 the "Fork" button. Then clone your fork to your local machine::
 
-    $ git clone git@github.com:your-user-name/numcodecs.git
+    $ git clone --recursive https://github.com/zarr-developers/numcodecs.git
     $ cd numcodecs
-    $ git remote add upstream git@github.com:zarr-developers/numcodecs.git
+    $ git remote add upstream https://github.com/zarr-developers/numcodecs.git
 
 Creating a development environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -98,6 +98,10 @@ the repository, you can do something like the following::
 To verify that your development environment is working, you can run the unit tests::
 
     $ pytest -v numcodecs
+
+To install numcodecs globally in editable mode run::
+
+    $ python -m pip install -e . 
 
 Creating a branch
 ~~~~~~~~~~~~~~~~~

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -77,14 +77,14 @@ the "Fork" button. Then clone your fork to your local machine::
 
     $ git clone --recursive git@github.com:your-user-name/numcodecs.git  # with ``ssh``
     
-    or
+or::
 
     $ git clone --recursive https://github.com/your-user-name/numcodecs.git  # with ``https``
 
-    Then `cd` into the clone:
+Then ``cd`` into the clone and add the ``upstream`` remote::
 
     $ cd numcodecs
-    $ git remote add upstream git@github.com:zarr-developers/numcodecs.git
+    $ git remote add upstream git@github.com:zarr-developers/numcodecs.git  # or use ``https``
 
 Creating a development environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -75,7 +75,7 @@ The NumCodecs source code is hosted on GitHub at the following location:
 You will need your own fork to work on the code. Go to the link above and hit
 the "Fork" button. Then clone your fork to your local machine::
 
-    $ git clone --recursive https://github.com/zarr-developers/numcodecs.git
+    $ git clone --recursive https://github.com/your-user-name/numcodecs.git
     $ cd numcodecs
     $ git remote add upstream https://github.com/zarr-developers/numcodecs.git
 


### PR DESCRIPTION
- use `--recursive` to clone the submodules too (I get a build error locally if `c-blosc` is not cloned)
- use the generic `HTTPS` URLs instead of the `SSH` ones (not everyone has `SSH` keys)
- specify a command to install `numcodecs` globally (I noticed that running `python setup.py build_ext --inplace` did not install `numcodecs` in my `python` environment, but as it correctly built the package, the tests passed)

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py310` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
