### PR TITLE
numcodecs.ndarray_like: speedup is_ndarray_like

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,7 +15,7 @@ Fix
 ~~~
 
 * Speed up isinstance checks of :class:`numcodecs.ndarray_like.NDArrayLike`,
-  :class:`numcodecs.ndarray_like.DType` and :class:`numcodecs.ndarray_like.FlagsObj`
+  :class:`numcodecs.ndarray_like.DType` and :class:`numcodecs.ndarray_like.FlagsObj`.
   By :user:`Andreas Poehlmann <ap-->`, :issue:`379`.
 
 Maintenance

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -11,6 +11,13 @@ Release notes
 Unreleased
 ----------
 
+Fix
+~~~
+
+* Speed up isinstance checks of :class:`numcodecs.ndarray_like.NDArrayLike`,
+  :class:`numcodecs.ndarray_like.DType` and :class:`numcodecs.ndarray_like.FlagsObj`
+  By :user:`Andreas Poehlmann <ap-->`, :issue:`379`.
+
 Maintenance
 ~~~~~~~~~~~
 

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -27,14 +27,14 @@ class _CachedProtocolMeta(Protocol.__class__):
 
 
 @runtime_checkable
-class DType(Protocol, metaclass=_CachedProtocolMeta):
+class DType(Protocol):
     itemsize: int
     name: str
     kind: str
 
 
 @runtime_checkable
-class FlagsObj(Protocol, metaclass=_CachedProtocolMeta):
+class FlagsObj(Protocol):
     c_contiguous: bool
     f_contiguous: bool
     owndata: bool

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Type
 
 if sys.version_info >= (3, 8):
     from typing import Protocol, runtime_checkable
@@ -7,22 +7,41 @@ else:
     from typing_extensions import Protocol, runtime_checkable
 
 
+class _CachedProtocolMeta(Protocol.__class__):
+    """Custom implementation of @runtime_checkable
+
+    The native implementation of @runtime_checkable is slow,
+    see <https://github.com/zarr-developers/numcodecs/issues/379>.
+
+    This metaclass keeps an unbounded cache of the result of
+    isinstance checks using the object's class as the cache key.
+    """
+    _instancecheck_cache: Dict[Type, bool] = {}
+
+    def __instancecheck__(cls, instance):
+        ret = cls._instancecheck_cache.get(instance.__class__, None)
+        if ret is None:
+            ret = super().__instancecheck__(instance)
+            cls._instancecheck_cache[instance.__class__] = ret
+        return ret
+
+
 @runtime_checkable
-class DType(Protocol):
+class DType(Protocol, metaclass=_CachedProtocolMeta):
     itemsize: int
     name: str
     kind: str
 
 
 @runtime_checkable
-class FlagsObj(Protocol):
+class FlagsObj(Protocol, metaclass=_CachedProtocolMeta):
     c_contiguous: bool
     f_contiguous: bool
     owndata: bool
 
 
 @runtime_checkable
-class NDArrayLike(Protocol):
+class NDArrayLike(Protocol, metaclass=_CachedProtocolMeta):
     dtype: DType
     shape: Tuple[int, ...]
     strides: Tuple[int, ...]
@@ -51,26 +70,6 @@ class NDArrayLike(Protocol):
         ...
 
 
-# keep in sync with NDArrayLike
-_NDArrayLike_protocol_attrs = [
-    "dtype",
-    "shape",
-    "strides",
-    "ndim",
-    "size",
-    "itemsize",
-    "nbytes",
-    "flags",
-    "__len__",
-    "__getitem__",
-    "__setitem__",
-    "tobytes",
-    "reshape",
-    "view",
-]
-
-
 def is_ndarray_like(obj: object) -> bool:
     """Return True when `obj` is ndarray-like"""
-    # same as `isinstance(obj, NDArrayLike)` but faster
-    return all(hasattr(obj, attr) for attr in _NDArrayLike_protocol_attrs)
+    return isinstance(obj, NDArrayLike)

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -18,12 +18,12 @@ class _CachedProtocolMeta(Protocol.__class__):
     """
     _instancecheck_cache: Dict[Tuple[Type, Type], bool] = {}
 
-    def __instancecheck__(cls, instance):
-        key = (cls, instance.__class__)
-        ret = cls._instancecheck_cache.get(key, None)
+    def __instancecheck__(self, instance):
+        key = (self, instance.__class__)
+        ret = self._instancecheck_cache.get(key, None)
         if ret is None:
             ret = super().__instancecheck__(instance)
-            cls._instancecheck_cache[key] = ret
+            self._instancecheck_cache[key] = ret
         return ret
 
 

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -16,25 +16,26 @@ class _CachedProtocolMeta(Protocol.__class__):
     This metaclass keeps an unbounded cache of the result of
     isinstance checks using the object's class as the cache key.
     """
-    _instancecheck_cache: Dict[Type, bool] = {}
+    _instancecheck_cache: Dict[Tuple[Type, Type], bool] = {}
 
     def __instancecheck__(cls, instance):
-        ret = cls._instancecheck_cache.get(instance.__class__, None)
+        key = (cls, instance.__class__)
+        ret = cls._instancecheck_cache.get(key, None)
         if ret is None:
             ret = super().__instancecheck__(instance)
-            cls._instancecheck_cache[instance.__class__] = ret
+            cls._instancecheck_cache[key] = ret
         return ret
 
 
 @runtime_checkable
-class DType(Protocol):
+class DType(Protocol, metaclass=_CachedProtocolMeta):
     itemsize: int
     name: str
     kind: str
 
 
 @runtime_checkable
-class FlagsObj(Protocol):
+class FlagsObj(Protocol, metaclass=_CachedProtocolMeta):
     c_contiguous: bool
     f_contiguous: bool
     owndata: bool

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -51,6 +51,26 @@ class NDArrayLike(Protocol):
         ...
 
 
+# keep in sync with NDArrayLike
+_NDArrayLike_protocol_attrs = [
+    "dtype",
+    "shape",
+    "strides",
+    "ndim",
+    "size",
+    "itemsize",
+    "nbytes",
+    "flags",
+    "__len__",
+    "__getitem__",
+    "__setitem__",
+    "tobytes",
+    "reshape",
+    "view",
+]
+
+
 def is_ndarray_like(obj: object) -> bool:
     """Return True when `obj` is ndarray-like"""
-    return isinstance(obj, NDArrayLike)
+    # same as `isinstance(obj, NDArrayLike)` but faster
+    return all(hasattr(obj, attr) for attr in _NDArrayLike_protocol_attrs)

--- a/numcodecs/tests/test_ndarray_like.py
+++ b/numcodecs/tests/test_ndarray_like.py
@@ -1,6 +1,6 @@
 import pytest
 
-from numcodecs.ndarray_like import NDArrayLike
+from numcodecs.ndarray_like import DType, FlagsObj, NDArrayLike
 
 
 @pytest.mark.parametrize("module", ["numpy", "cupy"])
@@ -13,3 +13,36 @@ def test_is_ndarray_like(module):
 def test_is_not_ndarray_like():
     assert not isinstance([1, 2, 3], NDArrayLike)
     assert not isinstance(b"1,2,3", NDArrayLike)
+
+
+@pytest.mark.parametrize("module", ["numpy", "cupy"])
+def test_is_dtype_like(module):
+    m = pytest.importorskip(module)
+    d = m.dtype("u8")
+    assert isinstance(d, DType)
+
+
+def test_is_not_dtype_like():
+    assert not isinstance([1, 2, 3], DType)
+    assert not isinstance(b"1,2,3", DType)
+
+
+@pytest.mark.parametrize("module", ["numpy", "cupy"])
+def test_is_flags_like(module):
+    m = pytest.importorskip(module)
+    d = m.arange(10).flags
+    assert isinstance(d, FlagsObj)
+
+
+def test_is_not_flags_like():
+    assert not isinstance([1, 2, 3], FlagsObj)
+    assert not isinstance(b"1,2,3", FlagsObj)
+
+
+@pytest.mark.parametrize("module", ["numpy", "cupy"])
+def test_cached_isinstance_check(module):
+    m = pytest.importorskip(module)
+    a = m.arange(10)
+    assert isinstance(a, NDArrayLike)
+    assert not isinstance(a, DType)
+    assert not isinstance(a, FlagsObj)


### PR DESCRIPTION
This PR reduces the runtime of `is_ndarray_like` and addresses #379

`is_ndarray_like()` calls `isinstance(obj, NDArrayLike)` where `NDArrayLike` is a runtime checkable Protocol class. For every check the protocol attributes are generated dynamically which can significantly contribute to the decode time in zarr arrays.

~This commit uses a pragmatic solution and duplicates the protocol attributes in the code base. This could be generated from `typing._get_protocol_attrs(NDArrayLike)` but would have to rely on private functionality of the typing module.~


TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] `tox -e py310` passes locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
