### PR TITLE
Update ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+version: 2
+
+submodules:
+  include: all
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: requirements_rtfd.txt
+    - method: pip
+      path: .

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -41,6 +41,9 @@ Maintenance
 
 * Add tests for all registry classes.
   By :user:`Josh Moore <joshmoore>`, :issue:`349`.
+  
+* Update ReadTheDocs.
+  By :user:`John Kirkham <jakirkham>`, :issue:`383`.
 
 .. _release_0.10.2:
 


### PR DESCRIPTION
Moves ReadTheDocs to [the new configuration file 2 format]( https://docs.readthedocs.io/en/stable/config-file/v2.html ).

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] `tox -e py310` passes locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] `tox -e docs` passes locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
