### PR TITLE
Reference Codecov in docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ TODO:
 - [ ] Changes documented in docs/release.rst
 - [ ] Docs build locally
 - [ ] GitHub Actions CI passes
-- [ ] Test coverage to 100% (Coveralls passes)
+- [ ] Test coverage to 100% (Codecov passes)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -179,8 +179,8 @@ and produce a coverage report. This should be 100% before code can be accepted i
 main code base.
 
 When submitting a pull request, coverage will also be collected across all supported
-Python versions via the Coveralls service, and will be reported back within the pull
-request. Coveralls coverage must also be 100% before code can be accepted.
+Python versions via the Codecov service, and will be reported back within the pull
+request. Codecov coverage must also be 100% before code can be accepted.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -217,7 +217,7 @@ one core developers before being merged. Ideally, pull requests submitted by a c
 should be reviewed and approved by at least one other core developers before being merged.
 
 Pull requests should not be merged until all CI checks have passed (Travis, AppVeyor,
-Coveralls) against code that has had the latest main merged in.
+Codecov) against code that has had the latest main merged in.
 
 Compatibility and versioning policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Remove outdated references to Coveralls and update with Codecov.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Coveralls passes)
