### PR TITLE
Unnecessary None provided as default

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -21,6 +21,9 @@ Fix
 Maintenance
 ~~~~~~~~~~~
 
+* Remove unnecessary None argument to .get(), it is the default value.
+  By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`395`.
+
 * Apply refurb suggestions.
   By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`372`.
 

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -20,7 +20,7 @@ class _CachedProtocolMeta(Protocol.__class__):
 
     def __instancecheck__(self, instance):
         key = (self, instance.__class__)
-        ret = self._instancecheck_cache.get(key, None)
+        ret = self._instancecheck_cache.get(key)
         if ret is None:
             ret = super().__instancecheck__(instance)
             self._instancecheck_cache[key] = ret


### PR DESCRIPTION
It is unnecessary to provide `None` as the default value when the key is not present in the dictionary as `get` implicitly returns `None`.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
