### PR TITLE
Use `conda-incubator/setup-miniconda@v2.2.0` (and use Conda on Linux)

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -17,22 +17,50 @@ jobs:
           submodules: recursive
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+            channels: conda-forge
+            python-version: ${{ matrix.python-version }}
+        env:
+            ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+      - name: Show info about `base` environment
+        shell: "bash -l {0}"
+        run: |
+          conda info
+          conda config --show-sources
+          conda list --show-channel-urls
+
+      - name: Set up env
+        shell: "bash -l {0}"
+        run: |
+          conda create -n env python=${{matrix.python-version}} wheel pip compilers
+          conda activate env
+          which pip
+          conda env export
+
+      - name: Show info about `env` environment
+        shell: "bash -l {0}"
+        run: |
+          conda list --show-channel-urls -n env
 
       - name: Install numcodecs
+        shell: "bash -l {0}"
         run: |
+          conda activate env
           python -m pip install -v -e .[test,msgpack,zfpy]
 
-      - name: List installed packages
-        run: python -m pip list
-
       - name: Flake8
-        run: flake8
+        shell: "bash -l {0}"
+        run: |
+          conda activate env
+          flake8
 
       - name: Run tests
-        run: pytest -v
+        shell: "bash -l {0}"
+        run: |
+          conda activate env
+          pytest -v
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Python
+      - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
             channels: conda-forge

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -21,8 +21,6 @@ jobs:
         with:
             channels: conda-forge
             python-version: ${{ matrix.python-version }}
-        env:
-            ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Show info about `base` environment
         shell: "bash -l {0}"

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -33,11 +33,9 @@ jobs:
 
       - name: Set up env
         shell: "bash -l {0}"
-        run: |
-          conda create -n env python=${{matrix.python-version}} wheel pip compilers
-          conda activate env
-          which pip
-          conda env export
+        run: >
+          conda create -n env python=${{matrix.python-version}} wheel pip
+                              c-compiler cxx-compiler
 
       - name: Show info about `env` environment
         shell: "bash -l {0}"

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -4,12 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        os: [ubuntu-latest]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -34,8 +34,9 @@ jobs:
       - name: Set up env
         shell: "bash -l {0}"
         run: >
-          conda create -n env python=${{matrix.python-version}} wheel pip
-                              c-compiler cxx-compiler
+          conda create -n env
+          c-compiler cxx-compiler
+          python=${{matrix.python-version}} wheel pip
 
       - name: Show info about `env` environment
         shell: "bash -l {0}"

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -29,7 +29,7 @@ jobs:
           conda config --show-sources
           conda list --show-channel-urls
 
-      - name: Set up env
+      - name: Set up `env`
         shell: "bash -l {0}"
         run: >
           conda create -n env

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -47,6 +47,7 @@ jobs:
         shell: "bash -l {0}"
         run: |
           conda activate env
+          export DISABLE_NUMCODECS_AVX2=""
           python -m pip install -v -e .[test,msgpack,zfpy]
 
       - name: Flake8

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -50,6 +50,12 @@ jobs:
           export DISABLE_NUMCODECS_AVX2=""
           python -m pip install -v -e .[test,msgpack,zfpy]
 
+      - name: List installed packages
+        shell: "bash -l {0}"
+        run: |
+          conda activate env
+          python -m pip list
+
       - name: Flake8
         shell: "bash -l {0}"
         run: |

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -17,50 +17,22 @@ jobs:
           submodules: recursive
 
       - name: Set up Python
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: actions/setup-python@v4
         with:
-            channels: conda-forge
-            python-version: ${{ matrix.python-version }}
-        env:
-            ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-
-      - name: Show info about `base` environment
-        shell: "bash -l {0}"
-        run: |
-          conda info
-          conda config --show-sources
-          conda list --show-channel-urls
-
-      - name: Set up env
-        shell: "bash -l {0}"
-        run: |
-          conda create -n env python=${{matrix.python-version}} wheel pip compilers
-          conda activate env
-          which pip
-          conda env export
-
-      - name: Show info about `env` environment
-        shell: "bash -l {0}"
-        run: |
-          conda list --show-channel-urls -n env
+          python-version: ${{ matrix.python-version }}
 
       - name: Install numcodecs
-        shell: "bash -l {0}"
         run: |
-          conda activate env
           python -m pip install -v -e .[test,msgpack,zfpy]
 
+      - name: List installed packages
+        run: python -m pip list
+
       - name: Flake8
-        shell: "bash -l {0}"
-        run: |
-          conda activate env
-          flake8
+        run: flake8
 
       - name: Run tests
-        shell: "bash -l {0}"
-        run: |
-          conda activate env
-          pytest -v
+        run: pytest -v
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Python
+      - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
             channels: conda-forge

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -21,8 +21,6 @@ jobs:
         with:
             channels: conda-forge
             python-version: ${{ matrix.python-version }}
-        env:
-            ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Show info about `base` environment
         shell: "bash -l {0}"

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -50,6 +50,12 @@ jobs:
           export CC=clang
           python -m pip install -v -e .[test,msgpack,zfpy]
 
+      - name: List installed packages
+        shell: "bash -l {0}"
+        run: |
+          conda activate env
+          python -m pip list
+
       - name: Run tests
         shell: "bash -l {0}"
         run: |

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Python
-        uses: conda-incubator/setup-miniconda@master
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
             channels: conda-forge
             python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -29,7 +29,7 @@ jobs:
           conda config --show-sources
           conda list --show-channel-urls
 
-      - name: Set up env
+      - name: Set up `env`
         shell: "bash -l {0}"
         run: >
           conda create -n env

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -33,11 +33,9 @@ jobs:
 
       - name: Set up env
         shell: "bash -l {0}"
-        run: |
-          conda create -n env python=${{matrix.python-version}} wheel pip compilers 'clang>=12.0.1'
-          conda activate env
-          which pip
-          conda env export
+        run: >
+          conda create -n env python=${{matrix.python-version}} wheel pip
+                              c-compiler cxx-compiler 'clang>=12.0.1'
 
       - name: Show info about `env` environment
         shell: "bash -l {0}"

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -34,8 +34,9 @@ jobs:
       - name: Set up env
         shell: "bash -l {0}"
         run: >
-          conda create -n env python=${{matrix.python-version}} wheel pip
-                              c-compiler cxx-compiler 'clang>=12.0.1'
+          conda create -n env
+          c-compiler cxx-compiler 'clang>=12.0.1'
+          python=${{matrix.python-version}} wheel pip
 
       - name: Show info about `env` environment
         shell: "bash -l {0}"

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -32,6 +32,11 @@ jobs:
           which pip
           conda env export
 
+      - name: Show info about `env` environment
+        shell: "bash -l {0}"
+        run: |
+          conda list --show-channel-urls -n env
+
       - name: Install numcodecs
         shell: "bash -l {0}"
         run: |

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -42,6 +42,12 @@ jobs:
           conda activate env
           python -m pip install -v -e .[test,msgpack,zfpy]
 
+      - name: List installed packages
+        shell: "bash -l {0}"
+        run: |
+          conda activate env
+          python -m pip list
+
       - name: Run tests
         shell: "bash -l {0}"
         run: |

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Python
+      - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
             channels: conda-forge

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Python
-        uses: conda-incubator/setup-miniconda@master
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
             channels: conda-forge
             python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -26,11 +26,9 @@ jobs:
 
       - name: Set up env
         shell: "bash -l {0}"
-        run: |
-          conda create -n env python=${{matrix.python-version}} wheel pip compilers
-          conda activate env
-          which pip
-          conda env export
+        run: >
+          conda create -n env python=${{matrix.python-version}} wheel pip
+                              c-compiler cxx-compiler
 
       - name: Show info about `env` environment
         shell: "bash -l {0}"

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -21,8 +21,6 @@ jobs:
         with:
             channels: conda-forge
             python-version: ${{ matrix.python-version }}
-        env:
-            ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Set up env
         shell: "bash -l {0}"

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -36,7 +36,6 @@ jobs:
         shell: "bash -l {0}"
         run: |
           conda activate env
-          export CC=clang
           python -m pip install -v -e .[test,msgpack,zfpy]
 
       - name: Run tests

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -27,8 +27,9 @@ jobs:
       - name: Set up env
         shell: "bash -l {0}"
         run: >
-          conda create -n env python=${{matrix.python-version}} wheel pip
-                              c-compiler cxx-compiler
+          conda create -n env
+          c-compiler cxx-compiler
+          python=${{matrix.python-version}} wheel pip
 
       - name: Show info about `env` environment
         shell: "bash -l {0}"

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -22,7 +22,7 @@ jobs:
             channels: conda-forge
             python-version: ${{ matrix.python-version }}
 
-      - name: Set up env
+      - name: Set up `env`
         shell: "bash -l {0}"
         run: >
           conda create -n env

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -65,6 +65,9 @@ Maintenance
 * Update ReadTheDocs.
   By :user:`John Kirkham <jakirkham>`, :issue:`383`.
 
+* Use `conda-incubator/setup-miniconda@v2.2.0` (and use Conda on Linux).
+  By :user:`John Kirkham <jakirkham>` :issue:`398`.
+
 * Bring coverage back up to 100%.
   By :user:`John Kirkham <jakirkham>` and :user:`Martin Durant <martindurant>`,
   :issue:`392` and :issue:`393`.


### PR DESCRIPTION
Update to the recent `conda-incubator/setup-miniconda` and pin that release. Also update Linux CI to also use Conda (just like on macOS & Windows). Drop Fortran compiler from CI as it is unused. Additionally drop `ACTIONS_ALLOW_UNSECURE_COMMANDS` as it is no longer needed. Some other small tidying.

xref: https://github.com/zarr-developers/zarr-python/pull/1263

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
