### PR TITLE
Cleanup ``import``s in ``adhoc/blosc_memleak_check.py``

### DIFF
--- a/adhoc/blosc_memleak_check.py
+++ b/adhoc/blosc_memleak_check.py
@@ -1,13 +1,11 @@
 import sys
 
-
-import numcodecs as codecs
-from numcodecs import blosc
+import numcodecs
 import numpy as np
 from numpy.testing import assert_array_equal
 
 
-codec = codecs.Blosc()
+codec = numcodecs.Blosc()
 data = np.arange(int(sys.argv[1]))
 for i in range(int(sys.argv[2])):
     enc = codec.encode(data)

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -7,6 +7,26 @@ Release notes
     # re-indented so that it does not show up in the notes.
 
 
+.. _unreleased:
+
+Unreleased
+----------
+
+Enhancements
+~~~~~~~~~~~~
+
+*
+
+Fix
+~~~
+
+*
+
+Maintenance
+~~~~~~~~~~~
+
+*
+
 .. _release_0.11.0:
 
 0.11.0

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -25,7 +25,8 @@ Fix
 Maintenance
 ~~~~~~~~~~~
 
-*
+* Cleanup ``import``s in ``adhoc/blosc_memleak_check.py``
+  By :user:`John Kirkham <jakirkham>`, :issue:`408`.
 
 .. _release_0.11.0:
 


### PR DESCRIPTION
Drop unused `import` and drop alias in script.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
