### PR TITLE
Enforce dtype=object for incompatible numpy array conversion

### DIFF
--- a/numcodecs/json.py
+++ b/numcodecs/json.py
@@ -54,7 +54,10 @@ class JSON(Codec):
         self._decoder = _json.JSONDecoder(**self._decoder_config)
 
     def encode(self, buf):
-        buf = np.asarray(buf)
+        try:
+            buf = np.asarray(buf)
+        except ValueError:
+            buf = np.asarray(buf, dtype=object)
         items = buf.tolist()
         items.extend((buf.dtype.str, buf.shape))
         return self._encoder.encode(items).encode(self._text_encoding)

--- a/numcodecs/msgpacks.py
+++ b/numcodecs/msgpacks.py
@@ -52,7 +52,10 @@ class MsgPack(Codec):
         self.raw = raw
 
     def encode(self, buf):
-        buf = np.asarray(buf)
+        try:
+            buf = np.asarray(buf)
+        except ValueError:
+            buf = np.asarray(buf, dtype=object)
         items = buf.tolist()
         items.extend((buf.dtype.str, buf.shape))
         return msgpack.packb(items, use_bin_type=self.use_bin_type,

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -2,6 +2,7 @@ import unittest
 
 
 import numpy as np
+import pytest
 
 
 try:
@@ -52,30 +53,32 @@ def test_backwards_compatibility():
     check_backwards_compatibility(codec.codec_id, arrays, [codec])
 
 
-def test_non_numpy_inputs():
+@pytest.mark.parametrize(
+    "input_data, dtype",
+    [
+        ([0, 1], None),
+        ([[0, 1], [2, 3]], None),
+        ([[0], [1], [2, 3]], object),
+        ([[[0, 0]], [[1, 1]], [[2, 3]]], None),
+        (["1"], None),
+        (["11", "11"], None),
+        (["11", "1", "1"], None),
+        ([{}], None),
+        ([{"key": "value"}, ["list", "of", "strings"]], object),
+        ([b"1"], None),
+        ([b"11", b"11"], None),
+        ([b"11", b"1", b"1"], None),
+        ([{b"key": b"value"}, [b"list", b"of", b"strings"]], object),
+    ]
+)
+def test_non_numpy_inputs(input_data, dtype):
     codec = MsgPack()
     # numpy will infer a range of different shapes and dtypes for these inputs.
     # Make sure that round-tripping through encode preserves this.
-    data = [
-        [0, 1],
-        [[0, 1], [2, 3]],
-        [[0], [1], [2, 3]],
-        [[[0, 0]], [[1, 1]], [[2, 3]]],
-        ["1"],
-        ["11", "11"],
-        ["11", "1", "1"],
-        [{}],
-        [{"key": "value"}, ["list", "of", "strings"]],
-        [b"1"],
-        [b"11", b"11"],
-        [b"11", b"1", b"1"],
-        [{b"key": b"value"}, [b"list", b"of", b"strings"]],
-    ]
-    for input_data in data:
-        actual = codec.decode(codec.encode(input_data))
-        expect = np.array(input_data)
-        assert expect.shape == actual.shape
-        assert np.array_equal(expect, actual)
+    actual = codec.decode(codec.encode(input_data))
+    expect = np.array(input_data, dtype=dtype)
+    assert expect.shape == actual.shape
+    assert np.array_equal(expect, actual)
 
 
 def test_encode_decode_shape_dtype_preserved():


### PR DESCRIPTION
Numpy 1.24 does not accept ragged sequences without `dtype=object` anymore: numpy/numpy#22004

Fixes #333

Before (https://github.com/zarr-developers/numcodecs/issues/333#issuecomment-1380670958 and #416): 

```
[   51s] ____________________________ test_non_numpy_inputs _____________________________
[   51s] 
[   51s]     def test_non_numpy_inputs():
[   51s]         # numpy will infer a range of different shapes and dtypes for these inputs.
[   51s]         # Make sure that round-tripping through encode preserves this.
[   51s]         data = [
[   51s]             [0, 1],
[   51s]             [[0, 1], [2, 3]],
[   51s]             [[0], [1], [2, 3]],
[   51s]             [[[0, 0]], [[1, 1]], [[2, 3]]],
[   51s]             ["1"],
[   51s]             ["11", "11"],
[   51s]             ["11", "1", "1"],
[   51s]             [{}],
[   51s]             [{"key": "value"}, ["list", "of", "strings"]],
[   51s]         ]
[   51s]         for input_data in data:
[   51s]             for codec in codecs:
[   51s] >               output_data = codec.decode(codec.encode(input_data))
[   51s] 
[   51s] ../../BUILDROOT/python-numcodecs-0.11.0-0.x86_64/usr/lib64/python3.8/site-packages/numcodecs/tests/test_json.py:72: 
[   51s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[   51s] 
[   51s] self = JSON(encoding='utf-8', allow_nan=True, check_circular=True, ensure_ascii=True,
[   51s]      indent=None, separators=(',', ':'), skipkeys=False, sort_keys=True,
[   51s]      strict=True)
[   51s] buf = [[0], [1], [2, 3]]
[   51s] 
[   51s]     def encode(self, buf):
[   51s] >       buf = np.asarray(buf)
[   51s] E       ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (3,) + inhomogeneous part.
[   51s] 
[   51s] ../../BUILDROOT/python-numcodecs-0.11.0-0.x86_64/usr/lib64/python3.8/site-packages/numcodecs/json.py:57: ValueError
[   51s] ____________________________ test_non_numpy_inputs _____________________________
[   51s] 
[   51s]     def test_non_numpy_inputs():
[   51s]         codec = MsgPack()
[   51s]         # numpy will infer a range of different shapes and dtypes for these inputs.
[   51s]         # Make sure that round-tripping through encode preserves this.
[   51s]         data = [
[   51s]             [0, 1],
[   51s]             [[0, 1], [2, 3]],
[   51s]             [[0], [1], [2, 3]],
[   51s]             [[[0, 0]], [[1, 1]], [[2, 3]]],
[   51s]             ["1"],
[   51s]             ["11", "11"],
[   51s]             ["11", "1", "1"],
[   51s]             [{}],
[   51s]             [{"key": "value"}, ["list", "of", "strings"]],
[   51s]             [b"1"],
[   51s]             [b"11", b"11"],
[   51s]             [b"11", b"1", b"1"],
[   51s]             [{b"key": b"value"}, [b"list", b"of", b"strings"]],
[   51s]         ]
[   51s]         for input_data in data:
[   51s] >           actual = codec.decode(codec.encode(input_data))
[   51s] 
[   51s] ../../BUILDROOT/python-numcodecs-0.11.0-0.x86_64/usr/lib64/python3.8/site-packages/numcodecs/tests/test_msgpacks.py:75: 
[   51s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[   51s] 
[   51s] self = MsgPack(raw=False, use_bin_type=True, use_single_float=False)
[   51s] buf = [[0], [1], [2, 3]]
[   51s] 
[   51s]     def encode(self, buf):
[   51s] >       buf = np.asarray(buf)
[   51s] E       ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (3,) + inhomogeneous part.
[   51s] 
[   51s] ../../BUILDROOT/python-numcodecs-0.11.0-0.x86_64/usr/lib64/python3.8/site-packages/numcodecs/msgpacks.py:55: ValueError
```