### PR TITLE
[CI] Use concurrency to cancel-in-progress workflows on new commit

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -2,6 +2,10 @@ name: Linux CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -2,6 +2,10 @@ name: OSX CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -2,6 +2,10 @@ name: Windows CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -2,6 +2,10 @@ name: Wheels
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheel on ${{ matrix.os }}


### PR DESCRIPTION
This PR adds concurrency and cancel-in-progress to the CI workflows. See:
https://docs.github.com/en/actions/using-jobs/using-concurrency
What this means is if workflows are running when a new commit is pushed, they are canceled and restarted, rather than piling up.

I tested this on my fork, see: https://github.com/psobolewskiPhD/numcodecs/actions/runs/4600373158

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
