### PR TITLE
[CI] use CIBW overrides to build arm64 macOS wheels

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -14,9 +14,10 @@ jobs:
       CIBW_TEST_COMMAND: pytest --pyargs numcodecs
       CIBW_TEST_REQUIRES: pytest
       CIBW_SKIP: "pp* cp36-* *-musllinux_* *win32 *_i686 *_s390x"
-      CIBW_ENVIRONMENT: "DISABLE_NUMCODECS_AVX2=1"
-      CIBW_ENVIRONMENT_MACOS: 'MACOSX_DEPLOYMENT_TARGET=10.9 DISABLE_NUMCODECS_AVX2=1 CFLAGS="$CFLAGS -Wno-implicit-function-declaration"'
-
+      CIBW_ARCHS_MACOS: 'x86_64 arm64'
+      CIBW_TEST_SKIP: '*-macosx_arm64'
+      # note: CIBW_ENVIRONMENT is now set in pyproject.toml
+      
     steps:
       - uses: actions/checkout@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,11 @@ norecursedirs = [
     "notebooks",
     "numcodecs.egg-info",
 ]
+[tool.cibuildwheel]
+ environment = { DISABLE_NUMCODECS_AVX2=1 }
+ [tool.cibuildwheel.macos]
+ environment = { MACOSX_DEPLOYMENT_TARGET=10.9, CFLAGS="$CFLAGS -Wno-implicit-function-declaration" }
+ [[tool.cibuildwheel.overrides]]
+ select = "*-macosx_arm64"
+ environment = { DISABLE_NUMCODECS_SSE2=1 }
+ 


### PR DESCRIPTION
At present numcodecs doesn't have wheels for arm64 macOS.
It builds from source just fine, but not everyone may have development tools.
Wheels make things potentially safer and of course faster.

closes: https://github.com/zarr-developers/numcodecs/issues/342

In this PR I add use of CIBW_ARCHS_MACOS to the existing workflow, setting 'x86_64 arm64'. This results in wheels cross compiled for arm64 in addition to the x86 ones. The runners are x86, so the arm64 wheels won't be tested.
However, this also requires using `overrides` to ensure that both AVX2 and SSE2 are disabled.
As a result, the ENVIROMENT aspects are moved to pyproject.toml

I tested this on my fork: https://github.com/psobolewskiPhD/numcodecs/pull/2 
I dowloaded the arm64 wheels, pip installed locally, and ran pytest:
```
====== 583 passed, 33 skipped, 36 xfailed, 1 xpassed, 5 warnings in 8.84s ======
```
Another option is to use `universal2` and build a FAT wheel for x86 and arm64. The existing wheels arn't too big, so this isn't so bad? But I assume arm64 is still in the minority, so maybe separate wheels are better?

Also from a CI time PoV, it's worth considering whether full pytest needs to run on wheels on top of the CI tests for each PR/push, see: https://github.com/zarr-developers/numcodecs/pull/427#issuecomment-1494928538

BTW: this same approach may be a cleaner way to implement https://github.com/zarr-developers/numcodecs/pull/315

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
