### PR TITLE
Temporarily pin down Sphinx to work around RTD bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Homepage = "https://github.com/zarr-developers/numcodecs"
 
 [project.optional-dependencies]
 docs = [
-    "sphinx",
+    "sphinx<7.0.0",
     "sphinx-issues",
     "numpydoc",
     "mock",


### PR DESCRIPTION
Fixes #433.

The RTD theme is not compatible with Sphinx 7.0.0. Pin down Sphinx until RTD fix this compatibility issue.

* https://github.com/readthedocs/readthedocs.org/issues/10279
* https://pullanswer.com/questions/project-fails-to-build-with-sphinx-7-0-0-jinja2-exceptions-undefinederror-style-is-undefined

The alternative is to force a different theme as in https://github.com/freeipa/freeipa/pull/6812.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [X] Docs build locally
- [X] GitHub Actions CI passes
- [X] Test coverage to 100% (Codecov passes)
