### PR TITLE
Remove Python 2 leftover

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # numcodecs documentation build configuration file, created by
 # sphinx-quickstart on Mon May  2 21:40:09 2016.


### PR DESCRIPTION
UTF-8 is the default encoding of sources in Python 3.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
