### PR TITLE
Change occurrences of format() to f-strings

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -21,6 +21,8 @@ Fix
 
 Maintenance
 ~~~~~~~~~~~
+* Change format() and old string formatting to f-strings.
+  By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`439`.
 
 * Remove pin on Sphinx
   By :user:`Elliott Sales de Andrade <QuLogic>`, :issue:`552`.

--- a/numcodecs/abc.py
+++ b/numcodecs/abc.py
@@ -120,9 +120,7 @@ class Codec(ABC):
 
         r = '%s(' % type(self).__name__
         params = [
-            '{}={!r}'.format(k, getattr(self, k))
-            for k in sorted(self.__dict__)
-            if not k.startswith('_')
+            f'{k}={getattr(self, k)!r}' for k in sorted(self.__dict__) if not k.startswith('_')
         ]
         r += ', '.join(params) + ')'
         return r

--- a/numcodecs/abc.py
+++ b/numcodecs/abc.py
@@ -118,7 +118,7 @@ class Codec(ABC):
         # by default, assume all non-private members are configuration
         # parameters and valid keyword arguments to constructor function
 
-        r = '%s(' % type(self).__name__
+        r = f'{type(self).__name__}('
         params = [
             f'{k}={getattr(self, k)!r}' for k in sorted(self.__dict__) if not k.startswith('_')
         ]

--- a/numcodecs/astype.py
+++ b/numcodecs/astype.py
@@ -73,6 +73,4 @@ class AsType(Codec):
         }
 
     def __repr__(self):
-        return '{}(encode_dtype={!r}, decode_dtype={!r})'.format(
-            type(self).__name__, self.encode_dtype.str, self.decode_dtype.str
-        )
+        return f'{type(self).__name__}(encode_dtype={self.encode_dtype.str!r}, decode_dtype={self.decode_dtype.str!r})'

--- a/numcodecs/categorize.py
+++ b/numcodecs/categorize.py
@@ -99,10 +99,4 @@ class Categorize(Codec):
         labels = repr(self.labels[:3])
         if len(self.labels) > 3:
             labels = labels[:-1] + ', ...]'
-        r = '%s(dtype=%r, astype=%r, labels=%s)' % (
-            type(self).__name__,
-            self.dtype.str,
-            self.astype.str,
-            labels,
-        )
-        return r
+        return f'{type(self).__name__}(dtype={self.dtype.str!r}, astype={self.astype.str!r}, labels={labels})'

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -115,7 +115,7 @@ def ensure_contiguous_ndarray_like(buf, max_buffer_size=None, flatten=True) -> N
         raise ValueError("an array with contiguous memory is required")
 
     if max_buffer_size is not None and arr.nbytes > max_buffer_size:
-        msg = "Codec does not support buffers of > {} bytes".format(max_buffer_size)
+        msg = f"Codec does not support buffers of > {max_buffer_size} bytes"
         raise ValueError(msg)
 
     return arr

--- a/numcodecs/delta.py
+++ b/numcodecs/delta.py
@@ -91,7 +91,7 @@ class Delta(Codec):
         return dict(id=self.codec_id, dtype=self.dtype.str, astype=self.astype.str)
 
     def __repr__(self):
-        r = '{}(dtype={!r}'.format(type(self).__name__, self.dtype.str)
+        r = f'{type(self).__name__}(dtype={self.dtype.str!r}'
         if self.astype != self.dtype:
             r += ', astype=%r' % self.astype.str
         r += ')'

--- a/numcodecs/delta.py
+++ b/numcodecs/delta.py
@@ -93,6 +93,6 @@ class Delta(Codec):
     def __repr__(self):
         r = f'{type(self).__name__}(dtype={self.dtype.str!r}'
         if self.astype != self.dtype:
-            r += ', astype=%r' % self.astype.str
+            r += f', astype={self.astype.str!r}'
         r += ')'
         return r

--- a/numcodecs/fixedscaleoffset.py
+++ b/numcodecs/fixedscaleoffset.py
@@ -126,13 +126,8 @@ class FixedScaleOffset(Codec):
         )
 
     def __repr__(self):
-        r = '%s(scale=%s, offset=%s, dtype=%r' % (
-            type(self).__name__,
-            self.scale,
-            self.offset,
-            self.dtype.str,
-        )
+        r = f'{type(self).__name__}(scale={self.scale}, offset={self.offset}, dtype={self.dtype.str!r}'
         if self.astype != self.dtype:
-            r += ', astype=%r' % self.astype.str
+            r += f', astype={self.astype.str!r}'
         r += ')'
         return r

--- a/numcodecs/json.py
+++ b/numcodecs/json.py
@@ -99,10 +99,11 @@ class JSON(Codec):
     def __repr__(self):
         params = ['encoding=%r' % self._text_encoding]
         for k, v in sorted(self._encoder_config.items()):
-            params.append('{}={!r}'.format(k, v))
+            params.append(f'{k}={v!r}')
         for k, v in sorted(self._decoder_config.items()):
-            params.append('{}={!r}'.format(k, v))
+            params.append(f'{k}={v!r}')
         classname = type(self).__name__
-        r = '{}({})'.format(classname, ', '.join(params))
-        r = textwrap.fill(r, width=80, break_long_words=False, subsequent_indent='     ')
-        return r
+        params = ', '.join(params)
+        return textwrap.fill(
+            f'{classname}({params})', width=80, break_long_words=False, subsequent_indent='     '
+        )

--- a/numcodecs/json.py
+++ b/numcodecs/json.py
@@ -97,7 +97,7 @@ class JSON(Codec):
         return config
 
     def __repr__(self):
-        params = ['encoding=%r' % self._text_encoding]
+        params = [f'encoding={self._text_encoding!r}']
         for k, v in sorted(self._encoder_config.items()):
             params.append(f'{k}={v!r}')
         for k, v in sorted(self._decoder_config.items()):

--- a/numcodecs/lzma.py
+++ b/numcodecs/lzma.py
@@ -66,11 +66,4 @@ if _lzma:
             return ndarray_copy(dec, out)
 
         def __repr__(self):
-            r = '%s(format=%r, check=%r, preset=%r, filters=%r)' % (
-                type(self).__name__,
-                self.format,
-                self.check,
-                self.preset,
-                self.filters,
-            )
-            return r
+            return f'{type(self).__name__}(format={self.format!r}, check={self.check!r}, preset={self.preset!r}, filters={self.filters!r})'

--- a/numcodecs/msgpacks.py
+++ b/numcodecs/msgpacks.py
@@ -84,6 +84,4 @@ class MsgPack(Codec):
         )
 
     def __repr__(self):
-        return 'MsgPack(raw={!r}, use_bin_type={!r}, use_single_float={!r})'.format(
-            self.raw, self.use_bin_type, self.use_single_float
-        )
+        return f'MsgPack(raw={self.raw!r}, use_bin_type={self.use_bin_type!r}, use_single_float={self.use_single_float!r})'

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Protocol, Tuple, Type, runtime_checkable
+from typing import Any, Optional, Protocol, runtime_checkable
 
 
 class _CachedProtocolMeta(Protocol.__class__):
@@ -11,7 +11,7 @@ class _CachedProtocolMeta(Protocol.__class__):
     isinstance checks using the object's class as the cache key.
     """
 
-    _instancecheck_cache: Dict[Tuple[Type, Type], bool] = {}
+    _instancecheck_cache: dict[tuple[type, type], bool] = {}
 
     def __instancecheck__(self, instance):
         key = (self, instance.__class__)
@@ -39,8 +39,8 @@ class FlagsObj(Protocol, metaclass=_CachedProtocolMeta):
 @runtime_checkable
 class NDArrayLike(Protocol, metaclass=_CachedProtocolMeta):
     dtype: DType
-    shape: Tuple[int, ...]
-    strides: Tuple[int, ...]
+    shape: tuple[int, ...]
+    strides: tuple[int, ...]
     ndim: int
     size: int
     itemsize: int

--- a/numcodecs/pickles.py
+++ b/numcodecs/pickles.py
@@ -52,4 +52,4 @@ class Pickle(Codec):
         return dict(id=self.codec_id, protocol=self.protocol)
 
     def __repr__(self):
-        return 'Pickle(protocol=%s)' % self.protocol
+        return f'Pickle(protocol={self.protocol})'

--- a/numcodecs/quantize.py
+++ b/numcodecs/quantize.py
@@ -95,12 +95,8 @@ class Quantize(Codec):
         )
 
     def __repr__(self):
-        r = '%s(digits=%s, dtype=%r' % (
-            type(self).__name__,
-            self.digits,
-            self.dtype.str,
-        )
+        r = f'{type(self).__name__}(digits={self.digits}, dtype={self.dtype.str!r}'
         if self.astype != self.dtype:
-            r += ', astype=%r' % self.astype.str
+            r += f', astype={self.astype.str!r}'
         r += ')'
         return r

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -49,7 +49,7 @@ def get_codec(config):
             register_codec(cls, codec_id=codec_id)
     if cls:
         return cls.from_config(config)
-    raise ValueError('codec not available: %r' % codec_id)
+    raise ValueError(f'codec not available: {codec_id!r}')
 
 
 def register_codec(cls, codec_id=None):

--- a/numcodecs/shuffle.py
+++ b/numcodecs/shuffle.py
@@ -57,5 +57,4 @@ class Shuffle(Codec):
         return out
 
     def __repr__(self):
-        r = '%s(elementsize=%s)' % (type(self).__name__, self.elementsize)
-        return r
+        return f'{type(self).__name__}(elementsize={self.elementsize})'

--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -258,7 +258,7 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
 
     # save fixture data
     for i, arr in enumerate(arrays):
-        arr_fn = os.path.join(fixture_dir, 'array.{:02d}.npy'.format(i))
+        arr_fn = os.path.join(fixture_dir, f'array.{i:02d}.npy')
         if not os.path.exists(arr_fn):  # pragma: no cover
             np.save(arr_fn, arr)
 
@@ -278,7 +278,7 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
                 pytest.skip("codec has been removed")
 
             # setup a directory to hold encoded data
-            codec_dir = os.path.join(fixture_dir, 'codec.{:02d}'.format(j))
+            codec_dir = os.path.join(fixture_dir, f'codec.{j:02d}')
             if not os.path.exists(codec_dir):  # pragma: no cover
                 os.makedirs(codec_dir)
 
@@ -293,7 +293,7 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
                 config = _json.load(cf)
                 assert codec == get_codec(config)
 
-            enc_fn = os.path.join(codec_dir, 'encoded.{:02d}.dat'.format(i))
+            enc_fn = os.path.join(codec_dir, f'encoded.{i:02d}.dat')
 
             # one time encode and save array
             if not os.path.exists(enc_fn):  # pragma: no cover

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -102,11 +102,8 @@ if _zfpy:
                 return dec
 
         def __repr__(self):
-            r = "%s(mode=%r, tolerance=%s, rate=%s, precision=%s)" % (
-                type(self).__name__,
-                self.mode,
-                self.tolerance,
-                self.rate,
-                self.precision,
+            return (
+                f"{type(self).__name__}(mode={self.mode!r}, "
+                f"tolerance={self.tolerance}, rate={self.rate}, "
+                f"precision={self.precision})"
             )
-            return r

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,5 +131,9 @@ environment = { DISABLE_NUMCODECS_AVX2=1, DISABLE_NUMCODECS_SSE2=1 }
 [tool.ruff]
 line-length = 100
 
+[tool.ruff.lint]
+extend-select = [ "UP" ]
+ignore = ["UP007"]
+
 [tool.ruff.format]
 quote-style = "preserve"


### PR DESCRIPTION
Also change one occurrence of `%` to `format()`, as changing to an f-string would result in a very long line.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
