### PR TITLE
Remove use of entrypoints

### DIFF
--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -1,7 +1,7 @@
 """The registry module provides some simple convenience functions to enable
 applications to dynamically register and look-up codec classes."""
+from importlib.metadata import entry_points
 import logging
-from contextlib import suppress
 
 logger = logging.getLogger("numcodecs")
 codec_registry = {}
@@ -9,13 +9,17 @@ entries = {}
 
 
 def run_entrypoints():
-    import entrypoints
     entries.clear()
-    entries.update(entrypoints.get_group_named("numcodecs.codecs"))
+    eps = entry_points()
+    if hasattr(eps, 'select'):
+        # If entry_points() has a select method, use that. Python 3.10+
+        entries.update(eps.select(group="numcodecs.codecs"))
+    else:
+        # Otherwise, fallback to using get
+        entries.update(eps.get("numcodecs.codecs", []))
 
 
-with suppress(ImportError):
-    run_entrypoints()
+run_entrypoints()
 
 
 def get_codec(config):

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -7,7 +7,6 @@ import numcodecs.registry
 
 
 here = os.path.abspath(os.path.dirname(__file__))
-pytest.importorskip("entrypoints")
 
 
 @pytest.fixture()
@@ -20,7 +19,6 @@ def set_path():
     numcodecs.registry.codec_registry.pop("test")
 
 
-@pytest.mark.xfail(reason="FIXME: not working in wheels build")
 def test_entrypoint_codec(set_path):
     cls = numcodecs.registry.get_codec({"id": "test"})
     assert cls.codec_id == "test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ in data storage and communication applications.
 """
 readme =  "README.rst"
 dependencies = [
-    "entrypoints",
     "numpy>=1.7",
 ]
 requires-python = ">=3.8"
@@ -70,6 +69,12 @@ license-files = ["LICENSE.txt"]
 package-dir = {"" = "."}
 packages = ["numcodecs", "numcodecs.tests"]
 zip-safe = false
+
+[tool.setuptools.package-data]
+numcodecs = [
+    "tests/package_with_entrypoint/__init__.py",
+    "tests/package_with_entrypoint-0.1.dist-info/entry_points.txt"
+]
 
 [tool.setuptools_scm]
 version_scheme = "guess-next-dev"


### PR DESCRIPTION
Since Python 3.8, the standard library has included functionality to query entry points directly using importlib.metadata. Since the API has changed for the better with Python 3.10, we need to support both ways of using it.