### PR TITLE
Fix Fletcher32.decode out keyword and test

### DIFF
--- a/numcodecs/fletcher32.pyx
+++ b/numcodecs/fletcher32.pyx
@@ -79,7 +79,7 @@ class Fletcher32(Codec):
                 f" match the expected checksum ({found}).\n"
                 "This could be a sign that the data has been corrupted."
             )
-        if out:
+        if out is not None:
             out.view("uint8")[:] = b[:-4]
             return out
         return memoryview(b[:-4])

--- a/numcodecs/tests/test_fletcher32.py
+++ b/numcodecs/tests/test_fletcher32.py
@@ -40,3 +40,10 @@ def test_known():
         1911, -2427, 1897, -2412, 2440, 873, -621, -829, 551, -2118,
     ]
     assert outarr.tolist() == expected
+
+
+def test_out():
+    data = np.frombuffer(bytearray(b"Hello World"), dtype="uint8")
+    f = Fletcher32()
+    result = f.encode(data)
+    f.decode(result, out=data)


### PR DESCRIPTION
Fix #448 , enable `out` keyword of `Fletcher32.decode`.

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
