### PR TITLE
[CI] Just test import for wheels

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -11,8 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      CIBW_TEST_COMMAND: pytest --pyargs numcodecs
-      CIBW_TEST_REQUIRES: pytest
+      CIBW_TEST_COMMAND: python -c 'import numcodecs'
       CIBW_SKIP: "pp* cp36-* *-musllinux_* *win32 *_i686 *_s390x"
       CIBW_ENVIRONMENT: "DISABLE_NUMCODECS_AVX2=1"
       CIBW_ENVIRONMENT_MACOS: 'MACOSX_DEPLOYMENT_TARGET=10.9 DISABLE_NUMCODECS_AVX2=1 CFLAGS="$CFLAGS -Wno-implicit-function-declaration"'

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      CIBW_TEST_COMMAND: python -c 'import numcodecs'
+      CIBW_TEST_COMMAND: python -c "import numcodecs"
       CIBW_SKIP: "pp* cp36-* *-musllinux_* *win32 *_i686 *_s390x"
       CIBW_ENVIRONMENT: "DISABLE_NUMCODECS_AVX2=1"
       CIBW_ENVIRONMENT_MACOS: 'MACOSX_DEPLOYMENT_TARGET=10.9 DISABLE_NUMCODECS_AVX2=1 CFLAGS="$CFLAGS -Wno-implicit-function-declaration"'


### PR DESCRIPTION
Currently, PR workflows run tests and build wheels. 
Meanwhile, the wheel workflow runs full tests again. 
This PR changes the wheel tests to just check that numcodecs is import-able, to reduce CI time.
See https://github.com/zarr-developers/numcodecs/pull/427#issuecomment-1494928538 and followup thread.

Note: could add something more to the command beyond importing, but I'm not sure what would be useful.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
