### PR TITLE
Add missing RTD requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,3 +17,5 @@ python:
       path: .
       extra_requirements:
         - docs
+        - msgpack
+        - zfpy

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -24,6 +24,9 @@ Fix
 ~~~
 
 * Fixed docs/Makefile error message when sphinx is not present
+  By :user:`Mark Kittisopikul <mkitti>`, :issue:`451`.
+* Add missing RTD requirements
+  By :user:`John Kirkham <jakirkham>`, :issue:`455`.
 
 Maintenance
 ~~~~~~~~~~~


### PR DESCRIPTION
Recent RTD doc builds (like [this one]( https://readthedocs.org/projects/numcodecs/builds/21552986/ )) started failing. From the log it appears one error is due to `zfpy` not being installed, which this fixes. Also added `msgpack` for good measure in case the same error shows up there (or those docs are not published due to a missing dependency suppressing the needed `import`).