### PR TITLE
Build docs using sphinx-rtd-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'numpydoc',
     'sphinx_issues',
+    'sphinx_rtd_theme',
 ]
 
 numpydoc_show_class_members = False
@@ -132,7 +133,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ docs = [
     "sphinx-issues",
     "numpydoc",
     "mock",
+    "sphinx_rtd_theme",
 ]
 test = [
     "coverage",
@@ -120,4 +121,3 @@ norecursedirs = [
  [[tool.cibuildwheel.overrides]]
  select = "*-macosx_arm64"
  environment = { DISABLE_NUMCODECS_SSE2=1 }
- 


### PR DESCRIPTION
This updates the doc config to use the sphinx-rtd-theme to build the docs. This is the theme that readthedocs uses to build the docs, so this PR make sure that docs built locally mirror the look of the rendered docs on readthedocs.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
