### PR TITLE
Add type hint checking with mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,10 @@ repos:
     rev: 2024.08.19
     hooks:
     - id: sp-repo-review
+
+  -   repo: https://github.com/pre-commit/mirrors-mypy
+      rev: 'v1.4.0'
+      hooks:
+      -   id: mypy
+          args: [--config-file, pyproject.toml]
+          additional_dependencies: [numpy, pytest, zfpy]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,4 @@ repos:
       hooks:
       -   id: mypy
           args: [--config-file, pyproject.toml]
-          additional_dependencies: [numpy, pytest, zfpy]
+          additional_dependencies: [numpy, pytest, zfpy, 'zarr==3.0.0b1']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,7 +232,7 @@ htmlhelp_basename = 'numcodecsdoc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     #'papersize': 'letterpaper',
     # The font size ('10pt', '11pt' or '12pt').

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-
 import os
 import sys
 from unittest.mock import Mock as MagicMock

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -26,6 +26,8 @@ Enhancements
   By :user:`Norman Rzepka <normanrz>`, :issue:`613`.
 * Add codec wrappers for Zarr 3.
   By :user:`Norman Rzepka <normanrz>`, :issue:`524`
+* Added mypy type checking to continuous integration.
+  By :user:`David Stansby <dstansby>`, :issue:`460`.
 
 Maintenance
 ~~~~~~~~~~~
@@ -146,8 +148,6 @@ Maintenance
 
 * Cleanup ``import``\ s in ``adhoc/blosc_memleak_check.py``
   By :user:`John Kirkham <jakirkham>`, :issue:`408`.
-* Added mypy type checking to continuous integration.
-  By :user:`David Stansby <dstansby>`, :issue:`460`.
 
 .. _release_0.11.0:
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -146,6 +146,8 @@ Maintenance
 
 * Cleanup ``import``\ s in ``adhoc/blosc_memleak_check.py``
   By :user:`John Kirkham <jakirkham>`, :issue:`408`.
+* Added mypy type checking to continuous integration.
+  By :user:`David Stansby <dstansby>`, :issue:`460`.
 
 .. _release_0.11.0:
 

--- a/numcodecs/abc.py
+++ b/numcodecs/abc.py
@@ -29,13 +29,14 @@ other and vice versa.
 """
 
 from abc import ABC, abstractmethod
+from typing import Optional
 
 
 class Codec(ABC):
     """Codec abstract base class."""
 
     # override in sub-class
-    codec_id = None
+    codec_id: Optional[str] = None
     """Codec identifier."""
 
     @abstractmethod

--- a/numcodecs/checksum32.py
+++ b/numcodecs/checksum32.py
@@ -1,6 +1,7 @@
 import struct
 import zlib
-from typing import Literal
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
@@ -8,12 +9,15 @@ from .abc import Codec
 from .compat import ensure_contiguous_ndarray, ndarray_copy
 from .jenkins import jenkins_lookup3
 
+if TYPE_CHECKING:
+    from typing_extensions import Buffer
+
 CHECKSUM_LOCATION = Literal['start', 'end']
 
 
 class Checksum32(Codec):
     # override in sub-class
-    checksum = None
+    checksum: Callable[["Buffer", int], int] | None = None
     location: CHECKSUM_LOCATION = 'start'
 
     def __init__(self, location: CHECKSUM_LOCATION | None = None):

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -100,7 +100,7 @@ def ensure_contiguous_ndarray_like(buf, max_buffer_size=None, flatten=True) -> N
 
     # check for datetime or timedelta ndarray, the buffer interface doesn't support those
     if arr.dtype.kind in "Mm":
-        arr = arr.view(np.int64)
+        arr = arr.view(np.int64)  # type: ignore[arg-type]
 
     # check memory is contiguous, if so flatten
     if arr.flags.c_contiguous or arr.flags.f_contiguous:
@@ -117,7 +117,7 @@ def ensure_contiguous_ndarray_like(buf, max_buffer_size=None, flatten=True) -> N
     return arr
 
 
-def ensure_contiguous_ndarray(buf, max_buffer_size=None, flatten=True) -> np.array:
+def ensure_contiguous_ndarray(buf, max_buffer_size=None, flatten=True) -> np.ndarray:
     """Convenience function to coerce `buf` to a numpy array, if it is not already a
     numpy array. Also ensures that the returned value exports fully contiguous memory,
     and supports the new-style buffer interface. If the optional max_buffer_size is

--- a/numcodecs/lzma.py
+++ b/numcodecs/lzma.py
@@ -1,11 +1,14 @@
-import contextlib
+from types import ModuleType
+from typing import Optional
 
-_lzma = None
+_lzma: Optional[ModuleType] = None
 try:
     import lzma as _lzma
 except ImportError:  # pragma: no cover
-    with contextlib.suppress(ImportError):
-        from backports import lzma as _lzma
+    try:
+        from backports import lzma as _lzma  # type: ignore[no-redef]
+    except ImportError:
+        pass
 
 
 if _lzma:

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -1,7 +1,7 @@
 from typing import Any, ClassVar, Optional, Protocol, runtime_checkable
 
 
-class _CachedProtocolMeta(Protocol.__class__):
+class _CachedProtocolMeta(type):
     """Custom implementation of @runtime_checkable
 
     The native implementation of @runtime_checkable is slow,

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -1,7 +1,7 @@
 from typing import Any, ClassVar, Optional, Protocol, runtime_checkable
 
 
-class _CachedProtocolMeta(type):
+class _CachedProtocolMeta(Protocol.__class__): # type: ignore[name-defined]
     """Custom implementation of @runtime_checkable
 
     The native implementation of @runtime_checkable is slow,

--- a/numcodecs/ndarray_like.py
+++ b/numcodecs/ndarray_like.py
@@ -1,7 +1,7 @@
 from typing import Any, ClassVar, Optional, Protocol, runtime_checkable
 
 
-class _CachedProtocolMeta(Protocol.__class__): # type: ignore[name-defined]
+class _CachedProtocolMeta(Protocol.__class__):  # type: ignore[name-defined]
     """Custom implementation of @runtime_checkable
 
     The native implementation of @runtime_checkable is slow,

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -2,13 +2,9 @@
 applications to dynamically register and look-up codec classes."""
 
 import logging
-from importlib.metadata import entry_points
-from typing import TYPE_CHECKING
+from importlib.metadata import EntryPoints, entry_points
 
 from numcodecs.abc import Codec
-
-if TYPE_CHECKING:
-    from importlib.metadata import EntryPoints
 
 logger = logging.getLogger("numcodecs")
 codec_registry: dict[str, Codec] = {}

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -2,13 +2,17 @@
 applications to dynamically register and look-up codec classes."""
 
 import logging
-from importlib.metadata import EntryPoints, entry_points
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
 
 from numcodecs.abc import Codec
 
+if TYPE_CHECKING:
+    from importlib.metadata import EntryPoints
+
 logger = logging.getLogger("numcodecs")
 codec_registry: dict[str, Codec] = {}
-entries: dict[str, EntryPoints] = {}
+entries: dict[str, "EntryPoints"] = {}
 
 
 def run_entrypoints():

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -2,11 +2,13 @@
 applications to dynamically register and look-up codec classes."""
 
 import logging
-from importlib.metadata import entry_points
+from importlib.metadata import EntryPoints, entry_points
+
+from numcodecs.abc import Codec
 
 logger = logging.getLogger("numcodecs")
-codec_registry = {}
-entries = {}
+codec_registry: dict[str, Codec] = {}
+entries: dict[str, EntryPoints] = {}
 
 
 def run_entrypoints():

--- a/numcodecs/tests/test_lzma.py
+++ b/numcodecs/tests/test_lzma.py
@@ -1,5 +1,7 @@
 import itertools
 import unittest
+from types import ModuleType
+from typing import cast
 
 import numpy as np
 import pytest
@@ -19,6 +21,8 @@ from numcodecs.tests.common import (
     check_err_encode_object_buffer,
     check_repr,
 )
+
+_lzma = cast(ModuleType, _lzma)
 
 codecs = [
     LZMA(),

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
-zarr = pytest.importorskip("zarr")
+if not TYPE_CHECKING:
+    zarr = pytest.importorskip("zarr")
+else:
+    import zarr
 
-import numcodecs.zarr3  # noqa: E402
+import zarr.storage
+from zarr.core.common import JSON
+
+import numcodecs.zarr3
 
 pytestmark = [
     pytest.mark.skipif(zarr.__version__ < "3.0.0", reason="zarr 3.0.0 or later is required"),
@@ -17,7 +25,6 @@ pytestmark = [
 
 get_codec_class = zarr.registry.get_codec_class
 Array = zarr.Array
-JSON = zarr.core.common.JSON
 BytesCodec = zarr.codecs.BytesCodec
 Store = zarr.abc.store.Store
 MemoryStore = zarr.storage.MemoryStore
@@ -28,7 +35,7 @@ EXPECTED_WARNING_STR = "Numcodecs codecs are not in the Zarr version 3.*"
 
 
 @pytest.fixture
-def store() -> Store:
+def store() -> StorePath:
     return StorePath(MemoryStore(mode="w"))
 
 
@@ -43,6 +50,8 @@ def test_entry_points(codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
 
 @pytest.mark.parametrize("codec_class", ALL_CODECS)
 def test_docstring(codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
+    if codec_class.__doc__ is None:
+        pytest.skip()
     assert "See :class:`numcodecs." in codec_class.__doc__
 
 
@@ -59,7 +68,7 @@ def test_docstring(codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
         numcodecs.zarr3.Shuffle,
     ],
 )
-def test_generic_codec_class(store: Store, codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
+def test_generic_codec_class(store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
     data = np.arange(0, 256, dtype="uint16").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -92,7 +101,9 @@ def test_generic_codec_class(store: Store, codec_class: type[numcodecs.zarr3._Nu
     ],
 )
 def test_generic_filter(
-    store: Store, codec_class: type[numcodecs.zarr3._NumcodecsCodec], codec_config: dict[str, JSON]
+    store: StorePath,
+    codec_class: type[numcodecs.zarr3._NumcodecsCodec],
+    codec_config: dict[str, JSON],
 ):
     data = np.linspace(0, 10, 256, dtype="float32").reshape((16, 16))
 
@@ -114,7 +125,7 @@ def test_generic_filter(
     np.testing.assert_array_equal(data, a[:, :])
 
 
-def test_generic_filter_bitround(store: Store):
+def test_generic_filter_bitround(store: StorePath):
     data = np.linspace(0, 1, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -132,7 +143,7 @@ def test_generic_filter_bitround(store: Store):
     assert np.allclose(data, a[:, :], atol=0.1)
 
 
-def test_generic_filter_quantize(store: Store):
+def test_generic_filter_quantize(store: StorePath):
     data = np.linspace(0, 10, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -150,7 +161,7 @@ def test_generic_filter_quantize(store: Store):
     assert np.allclose(data, a[:, :], atol=0.001)
 
 
-def test_generic_filter_packbits(store: Store):
+def test_generic_filter_packbits(store: StorePath):
     data = np.zeros((16, 16), dtype="bool")
     data[0:4, :] = True
 
@@ -189,7 +200,7 @@ def test_generic_filter_packbits(store: Store):
         numcodecs.zarr3.JenkinsLookup3,
     ],
 )
-def test_generic_checksum(store: Store, codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
+def test_generic_checksum(store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
     data = np.linspace(0, 10, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -208,7 +219,7 @@ def test_generic_checksum(store: Store, codec_class: type[numcodecs.zarr3._Numco
 
 
 @pytest.mark.parametrize("codec_class", [numcodecs.zarr3.PCodec, numcodecs.zarr3.ZFPY])
-def test_generic_bytes_codec(store: Store, codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
+def test_generic_bytes_codec(store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
     try:
         codec_class()._codec  # noqa: B018
     except ValueError as e:

--- a/numcodecs/tests/test_zfpy.py
+++ b/numcodecs/tests/test_zfpy.py
@@ -1,3 +1,6 @@
+from types import ModuleType
+from typing import cast
+
 import numpy as np
 import pytest
 
@@ -16,6 +19,9 @@ from numcodecs.tests.common import (
     check_err_encode_object_buffer,
     check_repr,
 )
+
+_zfpy = cast(ModuleType, _zfpy)
+
 
 codecs = [
     ZFPY(mode=_zfpy.mode_fixed_rate, rate=-1),

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -281,7 +281,7 @@ class FixedScaleOffset(_NumcodecsArrayArrayCodec):
 
     def resolve_metadata(self, chunk_spec: ArraySpec) -> ArraySpec:
         if astype := self.codec_config.get("astype"):
-            return replace(chunk_spec, dtype=np.dtype(astype))
+            return replace(chunk_spec, dtype=np.dtype(astype))  # type: ignore[arg-type]
         return chunk_spec
 
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> FixedScaleOffset:
@@ -330,7 +330,7 @@ class AsType(_NumcodecsArrayArrayCodec):
         super().__init__(**codec_config)
 
     def resolve_metadata(self, chunk_spec: ArraySpec) -> ArraySpec:
-        return replace(chunk_spec, dtype=np.dtype(self.codec_config["encode_dtype"]))
+        return replace(chunk_spec, dtype=np.dtype(self.codec_config["encode_dtype"]))  # type: ignore[arg-type]
 
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> AsType:
         decode_dtype = self.codec_config.get("decode_dtype")

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -44,6 +44,7 @@ except ImportError:  # pragma: no cover
     raise ImportError("zarr 3.0.0 or later is required to use the numcodecs zarr integration.")
 
 from zarr.abc.codec import ArrayArrayCodec, ArrayBytesCodec, BytesBytesCodec
+from zarr.abc.metadata import Metadata
 from zarr.core.array_spec import ArraySpec
 from zarr.core.buffer import Buffer, BufferPrototype, NDBuffer
 from zarr.core.buffer.cpu import as_numpy_array_wrapper
@@ -71,7 +72,7 @@ def _parse_codec_configuration(data: dict[str, JSON]) -> dict[str, JSON]:
 
 
 @dataclass(frozen=True)
-class _NumcodecsCodec:
+class _NumcodecsCodec(Metadata):
     codec_name: str
     codec_config: dict[str, JSON]
 

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -1,8 +1,10 @@
 import warnings
 from contextlib import suppress
 from importlib.metadata import PackageNotFoundError, version
+from types import ModuleType
+from typing import Optional
 
-_zfpy = None
+_zfpy: Optional[ModuleType] = None
 
 _zfpy_version: tuple = ()
 with suppress(PackageNotFoundError):
@@ -21,7 +23,7 @@ if _zfpy_version:
         )
     else:
         with suppress(ImportError):
-            import zfpy as _zfpy
+            import zfpy as _zfpy  # type: ignore[no-redef]
 
 if _zfpy:
     import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,3 +204,7 @@ quote-style = "preserve"
 [tool.mypy]
 ignore_errors = false
 ignore_missing_imports = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+# TODO: set options below to true
+strict = false
+warn_unreachable = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,3 +200,7 @@ ignore = [
 
 [tool.ruff.format]
 quote-style = "preserve"
+
+[tool.mypy]
+ignore_errors = false
+ignore_missing_imports = true


### PR DESCRIPTION
This is a starting point to work towards https://github.com/zarr-developers/numcodecs/issues/443. It:

- Adds configuration to run `mypy`
- `pre-commit-config.yaml` to run the type checking using [`pre-commit`](https://pre-commit.com/).
- Fixes type checking errors so that running `mypy` at least passes on the current code base.

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
