### PR TITLE
Fix warning in CI jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "numcodecs"
 description = """
-A Python package providing buffer compression and transformation codecs for use
-in data storage and communication applications.
-"""
+A Python package providing buffer compression and transformation codecs \
+for use in data storage and communication applications."""
 readme =  "README.rst"
 dependencies = [
     "numpy>=1.7",


### PR DESCRIPTION
```
  !!

          ********************************************************************************
          newlines are not allowed in `summary` and will break in the future
          ********************************************************************************

  !!
```
See for example https://github.com/zarr-developers/numcodecs/actions/runs/6348938987/job/17246365647.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [x] Docs build locally
- [ ] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
