### PR TITLE
Fix error in CI jobs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,3 +12,4 @@ exclude =
     fixture,
     notebooks,
     numcodecs.egg-info,
+    numcodecs/version.py,


### PR DESCRIPTION
Fixes this error:
```
▼ Run conda activate env
  conda activate env
  flake8
  shell: /usr/bin/bash -l {0}
  env:
    INPUT_RUN_POST: true
    CONDA_PKGS_DIR: /home/runner/conda_pkgs_dir
./numcodecs/version.py:5:5: F[4](https://github.com/zarr-developers/numcodecs/actions/runs/6349262059/job/17247197031?pr=467#step:9:4)01 'typing.Tuple' imported but unused
Error: Process completed with exit code 1.
```

Pinning `setuptools-scm` to a newer version might also fix this issue at some point (https://github.com/pypa/setuptools_scm/issues/482#issuecomment-1740038939), but in any case having linters skip generated files beyond our control is good practice.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
