### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout source

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -19,6 +19,8 @@ Enhancements
   By :user:`Martin Durant <martindurant>`, :issue:`410`.
 * Add ``jenkins_lookup3`` checksum codec
   By :user:`Mark Kittisopkul <mkitti>`, :issue:`445`.
+* Support Python 3.12.
+  By :user:`John Kirkham <jakirkham>`, :issue:`471`.
 
 Fix
 ~~~

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -13,7 +13,7 @@ def run_entrypoints():
     eps = entry_points()
     if hasattr(eps, 'select'):
         # If entry_points() has a select method, use that. Python 3.10+
-        entries.update(eps.select(group="numcodecs.codecs"))
+        entries.update({e.name: e for e in eps.select(group="numcodecs.codecs")})
     else:
         # Otherwise, fallback to using get
         entries.update(eps.get("numcodecs.codecs", []))


### PR DESCRIPTION
Add support for Python 3.12.

<hr>

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
