### PR TITLE
`Codec` is now derived from `abc.ABC`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,6 +6,16 @@ Release notes
     # to document your changes. On releases it will be
     # re-indented so that it does not show up in the notes.
 
+.. _release_0.12.1:
+
+0.12.1
+------
+
+Fix
+~~~
+
+* `Codec` is now derived from `abc.ABC`
+  By :user:`Mads R. B. Kristensen <madsbk>`, :issue:`472`.
 
 .. _release_0.12.0:
 

--- a/numcodecs/abc.py
+++ b/numcodecs/abc.py
@@ -29,10 +29,10 @@ other and vice versa.
 """
 
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 
-class Codec:
+class Codec(ABC):
     """Codec abstract base class."""
 
     # override in sub-class


### PR DESCRIPTION
In `Codec` we have some `@abstractmethod`, which is being ignore because  `Codec` isn't inheriting from `abc.ABC`. Fixed.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
