### PR TITLE
Fix default entrypoint handling on older Pythons

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           conda activate env
           export DISABLE_NUMCODECS_AVX2=""
-          python -m pip install -v -e .[test,msgpack,zfpy]
+          python -m pip install -v -e .[test,test_extras,msgpack,zfpy]
 
       - name: List installed packages
         shell: "bash -l {0}"

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           conda activate env
           export DISABLE_NUMCODECS_AVX2=""
-          python -m pip install -v -e .[test,msgpack,zfpy]
+          python -m pip install -v -e .[test,test_extras,msgpack,zfpy]
 
       - name: List installed packages
         shell: "bash -l {0}"

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -42,7 +42,7 @@ jobs:
         shell: "bash -l {0}"
         run: |
           conda activate env
-          python -m pip install -v -e .[test,msgpack,zfpy]
+          python -m pip install -v -e .[test,test_extras,msgpack,zfpy]
 
       - name: List installed packages
         shell: "bash -l {0}"

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -7,6 +7,17 @@ Release notes
     # re-indented so that it does not show up in the notes.
 
 
+.. _release_0.12.1:
+
+0.12.1
+------
+
+Fix
+~~~
+
+* Fix default entrypoint handling on older Pythons
+  By :user:`Vyas Ramasubramani <vyasr>`, :issue:`475`.
+
 .. _release_0.12.0:
 
 0.12.0

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -16,7 +16,7 @@ Fix
 ~~~
 
 * Fix default entrypoint handling on older Pythons
-  By :user:`Vyas Ramasubramani <vyasr>`, :issue:`475`.
+  By :user:`Vyas Ramasubramani <vyasr>`, :issue:`478`.
 
 .. _release_0.12.0:
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -16,15 +16,6 @@ Fix
 
 * `Codec` is now derived from `abc.ABC`
   By :user:`Mads R. B. Kristensen <madsbk>`, :issue:`472`.
-
-.. _release_0.12.1:
-
-0.12.1
-------
-
-Fix
-~~~
-
 * Fix handling of entry points on older Python versions where importlib_metadata compatibility is concerned
   By :user:`Vyas Ramasubramani <vyasr>`, :issue:`478`.
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,7 +15,7 @@ Release notes
 Fix
 ~~~
 
-* Fix default entrypoint handling on older Pythons
+* Fix handling of entry points on older Python versions where importlib_metadata compatibility is concerned
   By :user:`Vyas Ramasubramani <vyasr>`, :issue:`478`.
 
 .. _release_0.12.0:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -16,7 +16,7 @@ Fix
 
 * ``Codec`` is now derived from ``abc.ABC``
   By :user:`Mads R. B. Kristensen <madsbk>`, :issue:`472`.
-* Fix handling of entry points on older Python versions where importlib_metadata compatibility is concerned
+* Fix handling of entry points on older Python versions where ``importlib_metadata`` compatibility is concerned
   By :user:`Vyas Ramasubramani <vyasr>`, :issue:`478`.
 * Make shuffle pyx functions ``noexcept``
   By :user:`Martin Durant <martindurant>`, :issue:`477`.

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -16,7 +16,7 @@ def run_entrypoints():
         entries.update({e.name: e for e in eps.select(group="numcodecs.codecs")})
     else:
         # Otherwise, fallback to using get
-        entries.update(eps.get("numcodecs.codecs", []))
+        entries.update(eps.get("numcodecs.codecs", {}))
 
 
 run_entrypoints()

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -16,7 +16,7 @@ def run_entrypoints():
         entries.update({e.name: e for e in eps.select(group="numcodecs.codecs")})
     else:
         # Otherwise, fallback to using get
-        entries.update(eps.get("numcodecs.codecs", {}))
+        entries.update({e.name: e for e in eps.get("numcodecs.codecs", [])})
 
 
 run_entrypoints()

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -4,6 +4,8 @@ from unittest import mock
 
 import pytest
 
+from multiprocessing import Process
+
 import numcodecs.registry
 
 
@@ -30,16 +32,19 @@ def test_entrypoint_codec():
     assert cls.codec_id == "test"
 
 
-def test_entrypoint_codec_with_importlib_metadata():
+def get_entrypoints_with_importlib_metadata_loaded():
     # importlib_metadata patches importlib.metadata, which can lead to breaking changes
     # to the APIs of EntryPoint objects used when registering entrypoints. Attempt to
     # isolate those changes to just this test.
-    with mock.patch.dict(sys.modules):
-        import importlib_metadata  # noqa: F401
-        sys.path.append(here)
-        numcodecs.registry.run_entrypoints()
-        cls = numcodecs.registry.get_codec({"id": "test"})
-        assert cls.codec_id == "test"
-        sys.path.remove(here)
-        numcodecs.registry.run_entrypoints()
-        numcodecs.registry.codec_registry.pop("test")
+    import importlib_metadata  # noqa: F401
+    sys.path.append(here)
+    numcodecs.registry.run_entrypoints()
+    cls = numcodecs.registry.get_codec({"id": "test"})
+    assert cls.codec_id == "test"
+
+
+def test_entrypoint_codec_with_importlib_metadata():
+    p = Process(target=get_entrypoints_with_importlib_metadata_loaded)
+    p.start()
+    p.join()
+    assert p.exitcode == 0

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -3,8 +3,6 @@ import sys
 
 import pytest
 
-from multiprocessing import Process
-
 import numcodecs.registry
 
 
@@ -29,21 +27,3 @@ def set_path_fixture():
 def test_entrypoint_codec():
     cls = numcodecs.registry.get_codec({"id": "test"})
     assert cls.codec_id == "test"
-
-
-def get_entrypoints_with_importlib_metadata_loaded():
-    # importlib_metadata patches importlib.metadata, which can lead to breaking changes
-    # to the APIs of EntryPoint objects used when registering entrypoints. Attempt to
-    # isolate those changes to just this test.
-    import importlib_metadata  # noqa: F401
-    sys.path.append(here)
-    numcodecs.registry.run_entrypoints()
-    cls = numcodecs.registry.get_codec({"id": "test"})
-    assert cls.codec_id == "test"
-
-
-def test_entrypoint_codec_with_importlib_metadata():
-    p = Process(target=get_entrypoints_with_importlib_metadata_loaded)
-    p.start()
-    p.join()
-    assert p.exitcode == 0

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -1,5 +1,6 @@
 import os.path
 import sys
+from unittest import mock
 
 import pytest
 
@@ -9,7 +10,6 @@ import numcodecs.registry
 here = os.path.abspath(os.path.dirname(__file__))
 
 
-@pytest.fixture()
 def set_path():
     sys.path.append(here)
     numcodecs.registry.run_entrypoints()
@@ -19,6 +19,27 @@ def set_path():
     numcodecs.registry.codec_registry.pop("test")
 
 
-def test_entrypoint_codec(set_path):
+@pytest.fixture()
+def set_path_fixture():
+    yield from set_path()
+
+
+@pytest.mark.usefixtures("set_path_fixture")
+def test_entrypoint_codec():
     cls = numcodecs.registry.get_codec({"id": "test"})
     assert cls.codec_id == "test"
+
+
+def test_entrypoint_codec_with_importlib_metadata():
+    # importlib_metadata patches importlib.metadata, which can lead to breaking changes
+    # to the APIs of EntryPoint objects used when registering entrypoints. Attempt to
+    # isolate those changes to just this test.
+    with mock.patch.dict(sys.modules):
+        import importlib_metadata
+        sys.path.append(here)
+        numcodecs.registry.run_entrypoints()
+        cls = numcodecs.registry.get_codec({"id": "test"})
+        assert cls.codec_id == "test"
+        sys.path.remove(here)
+        numcodecs.registry.run_entrypoints()
+        numcodecs.registry.codec_registry.pop("test")

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -35,7 +35,7 @@ def test_entrypoint_codec_with_importlib_metadata():
     # to the APIs of EntryPoint objects used when registering entrypoints. Attempt to
     # isolate those changes to just this test.
     with mock.patch.dict(sys.modules):
-        import importlib_metadata
+        import importlib_metadata  # noqa: F401
         sys.path.append(here)
         numcodecs.registry.run_entrypoints()
         cls = numcodecs.registry.get_codec({"id": "test"})

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -1,6 +1,5 @@
 import os.path
 import sys
-from unittest import mock
 
 import pytest
 

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -9,6 +9,7 @@ import numcodecs.registry
 here = os.path.abspath(os.path.dirname(__file__))
 
 
+@pytest.fixture()
 def set_path():
     sys.path.append(here)
     numcodecs.registry.run_entrypoints()
@@ -18,12 +19,7 @@ def set_path():
     numcodecs.registry.codec_registry.pop("test")
 
 
-@pytest.fixture()
-def set_path_fixture():
-    yield from set_path()
-
-
-@pytest.mark.usefixtures("set_path_fixture")
+@pytest.mark.usefixtures("set_path")
 def test_entrypoint_codec():
     cls = numcodecs.registry.get_codec({"id": "test"})
     assert cls.codec_id == "test"

--- a/numcodecs/tests/test_entrypoints_backport.py
+++ b/numcodecs/tests/test_entrypoints_backport.py
@@ -8,7 +8,7 @@ from multiprocessing import Process
 
 import numcodecs.registry
 
-if not pkgutil.find_loader("importlib_metadata"):
+if not pkgutil.find_loader("importlib_metadata"):  # pragma: no cover
     pytest.skip("This test module requires importlib_metadata to be installed")
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/numcodecs/tests/test_entrypoints_backport.py
+++ b/numcodecs/tests/test_entrypoints_backport.py
@@ -1,0 +1,32 @@
+import os.path
+import pkgutil
+import sys
+
+import pytest
+
+from multiprocessing import Process
+
+import numcodecs.registry
+
+if not pkgutil.find_loader("importlib_metadata"):
+    pytest.skip("This test module requires importlib_metadata to be installed")
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_entrypoints_with_importlib_metadata_loaded():
+    # importlib_metadata patches importlib.metadata, which can lead to breaking changes
+    # to the APIs of EntryPoint objects used when registering entrypoints. Attempt to
+    # isolate those changes to just this test.
+    import importlib_metadata  # noqa: F401
+    sys.path.append(here)
+    numcodecs.registry.run_entrypoints()
+    cls = numcodecs.registry.get_codec({"id": "test"})
+    assert cls.codec_id == "test"
+
+
+def test_entrypoint_codec_with_importlib_metadata():
+    p = Process(target=get_entrypoints_with_importlib_metadata_loaded)
+    p.start()
+    p.join()
+    assert p.exitcode == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ test = [
     "flake8",
     "pytest",
     "pytest-cov",
+]
+test_extras = [
     "importlib_metadata",
 ]
 msgpack = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
     "flake8",
     "pytest",
     "pytest-cov",
+    "importlib_metadata",
 ]
 msgpack = [
     "msgpack",


### PR DESCRIPTION
The fallback here for updating a dictionary needs to be a dictionary, not a list.

I haven't added any new tests or anything, but I can if I'm pointed in the right direction. Not sure how this library wants to test these types of edge cases with entry points.

Resolves #478 

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
