### PR TITLE
Make shuffle pyx functions `noexcept`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,8 +14,10 @@ Release notes
 Fix
 ~~~
 
-* `Codec` is now derived from `abc.ABC`
+* ``Codec`` is now derived from ``abc.ABC``
   By :user:`Mads R. B. Kristensen <madsbk>`, :issue:`472`.
+* Make shuffle pyx functions ``noexcept``
+  By :user:`Martin Durant <martindurant>`, :issue:`477`.
 
 .. _release_0.12.0:
 

--- a/numcodecs/_shuffle.pyx
+++ b/numcodecs/_shuffle.pyx
@@ -8,7 +8,7 @@ cimport cython
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef void _doShuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_ssize_t element_size) nogil:
+cpdef int _doShuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_ssize_t element_size) nogil:
     cdef Py_ssize_t count, i, j, offset, byte_index
     count = len(src) // element_size
     for i in range(count):
@@ -20,7 +20,7 @@ cpdef void _doShuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_s
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef void _doUnshuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_ssize_t element_size) nogil:
+cpdef int _doUnshuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_ssize_t element_size) nogil:
     cdef Py_ssize_t count, i, j, offset, byte_index
     count = len(src) // element_size
     for i in range(element_size):

--- a/numcodecs/_shuffle.pyx
+++ b/numcodecs/_shuffle.pyx
@@ -20,7 +20,7 @@ cpdef void _doShuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_s
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef int _doUnshuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_ssize_t element_size) nogil:
+cpdef void _doUnshuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_ssize_t element_size) noexcept nogil:
     cdef Py_ssize_t count, i, j, offset, byte_index
     count = len(src) // element_size
     for i in range(element_size):

--- a/numcodecs/_shuffle.pyx
+++ b/numcodecs/_shuffle.pyx
@@ -8,7 +8,7 @@ cimport cython
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef int _doShuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_ssize_t element_size) nogil:
+cpdef void _doShuffle(const unsigned char[::1] src, unsigned char[::1] des, Py_ssize_t element_size) noexcept nogil:
     cdef Py_ssize_t count, i, j, offset, byte_index
     count = len(src) // element_size
     for i in range(count):


### PR DESCRIPTION
Fixes #476 

@jakirkham , like this? The functions don't actually return anything. 

Do we have any process to determine which codecs release the GIL? Given the performance discussions, this could be imporant.