### PR TITLE
[CI] Ensure [tool.cibuildwheel.macos] also has DISABLE_NUMCODECS_AVX2=1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,10 +113,9 @@ norecursedirs = [
     "numcodecs.egg-info",
 ]
 [tool.cibuildwheel]
- environment = { DISABLE_NUMCODECS_AVX2=1 }
- [tool.cibuildwheel.macos]
- environment = { MACOSX_DEPLOYMENT_TARGET=10.9, CFLAGS="$CFLAGS -Wno-implicit-function-declaration" }
- [[tool.cibuildwheel.overrides]]
- select = "*-macosx_arm64"
- environment = { DISABLE_NUMCODECS_SSE2=1 }
- 
+environment = { DISABLE_NUMCODECS_AVX2=1 }
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET=10.9, DISABLE_NUMCODECS_AVX2=1, CFLAGS="$CFLAGS -Wno-implicit-function-declaration" }
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_arm64"
+environment = { DISABLE_NUMCODECS_SSE2=1 } 


### PR DESCRIPTION
Closes https://github.com/zarr-developers/numcodecs/issues/473
This PR adds (back) `DISABLE_NUMCODECS_AVX2=1 ` to `[tool.cibuildwheel.macos]` in pyproject.toml to prevent failures if runner doesn't support AVX2.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
