### PR TITLE
Fix intermittent macOS GHA build issues w/AVX2

### DIFF
--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -49,7 +49,6 @@ jobs:
         shell: "bash -l {0}"
         run: |
           conda activate env
-          export CC=clang
           python -m pip install -v -e .[test,msgpack,zfpy]
 
       - name: List installed packages

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -49,6 +49,7 @@ jobs:
         shell: "bash -l {0}"
         run: |
           conda activate env
+          export DISABLE_NUMCODECS_AVX2=""
           python -m pip install -v -e .[test,msgpack,zfpy]
 
       - name: List installed packages


### PR DESCRIPTION
Lately there have been intermittent build issues on macOS GHA as AVX2 instructions are being used with the build. To fix this, try just turning off AVX2 on macOS GHA builds.

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
