### PR TITLE
Disable AVX2 in macOS ARM wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,4 +118,4 @@ environment = { DISABLE_NUMCODECS_AVX2=1 }
 environment = { MACOSX_DEPLOYMENT_TARGET=10.9, DISABLE_NUMCODECS_AVX2=1, CFLAGS="$CFLAGS -Wno-implicit-function-declaration" }
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
-environment = { DISABLE_NUMCODECS_SSE2=1 } 
+environment = { DISABLE_NUMCODECS_AVX2=1, DISABLE_NUMCODECS_SSE2=1 }


### PR DESCRIPTION
As AVX2 is an `x86_64` feature, ARM understandably doesn't have it. However for some reason macOS ARM wheels are building with this functionality enabled. So disable it in `pyproject.toml`. Hopefully this should fix that issue.

Fixes https://github.com/zarr-developers/numcodecs/issues/473

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
