### PR TITLE
Use PyData theme for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,7 +132,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,6 +14,9 @@ Unreleased
 Enhancements
 ~~~~~~~~~~~~
 
+* Use PyData theme for docs
+  By :user:`John Kirkham <jakirkham>`, :issue:`485`.
+
 Fix
 ~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ Homepage = "https://github.com/zarr-developers/numcodecs"
 docs = [
     "sphinx<7.0.0",
     "sphinx-issues",
+    "pydata-sphinx-theme",
     "numpydoc",
     "mock",
 ]


### PR DESCRIPTION
Make use of the PyData theme in the docs.

Previously RTD installed and configured the default `html_theme` to use `sphinx-rtd-theme`, which was ok. However RTD recently changed this as explained in [this blogpost]( https://blog.readthedocs.com/defaulting-latest-build-tools/ ). As a result, the docs started using the Sphinx default.

Taking this opportunity to more closely align the Numcodecs docs with the Zarr docs, which use the PyData theme ( https://github.com/zarr-developers/zarr-python/pull/1242 ). This should have a more seamless experience for the reader.

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
