### PR TITLE
Fix skip in entrypoints backport tests

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -20,6 +20,9 @@ Enhancements
 Fix
 ~~~
 
+* Fix skip of entry points backport tests
+  By :user:`Elliott Sales de Andrade <QuLogic>`, :issue:`487`.
+
 Maintenance
 ~~~~~~~~~~~
 

--- a/numcodecs/tests/test_entrypoints_backport.py
+++ b/numcodecs/tests/test_entrypoints_backport.py
@@ -9,7 +9,8 @@ from multiprocessing import Process
 import numcodecs.registry
 
 if not pkgutil.find_loader("importlib_metadata"):  # pragma: no cover
-    pytest.skip("This test module requires importlib_metadata to be installed")
+    pytest.skip("This test module requires importlib_metadata to be installed",
+                allow_module_level=True)
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
If `importlib_metadata` is not installed, then you get an error in collection:
```
Using pytest.skip outside of a test will skip the entire module. If that's your intention, pass `allow_module_level=True`. If you want to skip a specific test or an entire class, use the @pytest.mark.skip or @pytest.mark.skipif decorators.
```

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [n/a] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
