### PR TITLE
DEV: add Cython generated files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 
 # setuptools-scm
 numcodecs/version.py
+
+# Cython generated
+numcodecs/*.c


### PR DESCRIPTION
To make sure they do not accidentally get re-committed.
