### PR TITLE
Update c-blosc (v1) to 1.21.5

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -22,9 +22,15 @@ Fix
 
 * Fix skip of entry points backport tests
   By :user:`Elliott Sales de Andrade <QuLogic>`, :issue:`487`.
+* Fix Upgrade to Zstd 1.5.5 due to potential corruption
+  By :user:`Mark Kittisopikul <mkitti>`, :issue:`429`
 
 Maintenance
 ~~~~~~~~~~~
+* Update c-blosc to 1.21.0 to 1.21.5, zstd from 1.4.8 to 1.5.5,
+  lz4 from 1.9.3 to 1.9.4, and zlib from 1.2.8 to to 1.2.13
+  By :user:`Mark Kittisopikul <mkitti>`, :issue:`500`
+
 
 .. _release_0.12.1:
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -22,7 +22,7 @@ Fix
 
 * Fix skip of entry points backport tests
   By :user:`Elliott Sales de Andrade <QuLogic>`, :issue:`487`.
-* Fix Upgrade to Zstd 1.5.5 due to potential corruption
+* Fix Upgrade to Zstd 1.5.5 due to potential corruption. 
   By :user:`Mark Kittisopikul <mkitti>`, :issue:`429`
 
 Maintenance


### PR DESCRIPTION
* Update c-blosc v1 to 1.21.5
* Fix #429 (upgrades Zstandard to 1.5.5)
* Compiles assembly files for x86_64 (.S files)
* Does not include minizip directory and thus does not confuse Python 3.8 header.

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
