### PR TITLE
Run macOS CI on intel based runners + pin max clang version

### DIFF
--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -38,7 +38,7 @@ jobs:
         shell: "bash -l {0}"
         run: >
           conda create -n env
-          c-compiler cxx-compiler 'clang>=12.0.1'
+          c-compiler cxx-compiler 'clang>=12.0.1,<17'
           python=${{matrix.python-version}} wheel pip
 
       - name: Show info about `env` environment

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -1,4 +1,4 @@
-name: OSX CI
+name: macOS CI
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-12]
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"
       CIBW_SKIP: "pp* cp36-* *-musllinux_* *win32 *_i686 *_s390x"
       CIBW_ARCHS_MACOS: 'x86_64 arm64'
       CIBW_TEST_SKIP: '*-macosx_arm64'
       # note: CIBW_ENVIRONMENT is now set in pyproject.toml
-      
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ A Python package providing buffer compression and transformation codecs \
 for use in data storage and communication applications."""
 readme =  "README.rst"
 dependencies = [
-    "numpy>=1.7",
+    "numpy>=1.7,<2",
 ]
 requires-python = ">=3.8"
 dynamic = [


### PR DESCRIPTION
GitHub updated the latest macOS runners to be arm-based, causing the CI to fail. This makes sure the existing CI is using intel based macOS runners - we can always add support for arm-based testing in a follow up PR.

Fixes https://github.com/zarr-developers/numcodecs/issues/527