### PR TITLE
Bump min Python to 3.10

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-osx.yaml
+++ b/.github/workflows/ci-osx.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -16,7 +16,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-12]
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"
-      CIBW_SKIP: "pp* cp36-* *-musllinux_* *win32 *_i686 *_s390x"
+      CIBW_BUILD: "cp310-* cp311-* cp312-*"
+      CIBW_SKIP: "pp* *-musllinux_* *win32 *_i686 *_s390x"
       CIBW_ARCHS_MACOS: 'x86_64 arm64'
       CIBW_TEST_SKIP: '*-macosx_arm64'
       # note: CIBW_ENVIRONMENT is now set in pyproject.toml
@@ -44,7 +45,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ submodules:
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -11,6 +11,10 @@ Release notes
 Unreleased
 ----------
 
+Maintenance
+~~~~~~~~~~~
+* The minimum supported Python version is now Python 3.10.
+
 Enhancements
 ~~~~~~~~~~~~
 
@@ -24,7 +28,7 @@ Fix
 
 * Fix skip of entry points backport tests
   By :user:`Elliott Sales de Andrade <QuLogic>`, :issue:`487`.
-* Fix Upgrade to Zstd 1.5.5 due to potential corruption. 
+* Fix Upgrade to Zstd 1.5.5 due to potential corruption.
   By :user:`Mark Kittisopikul <mkitti>`, :issue:`429`
 
 Maintenance

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -11,12 +11,7 @@ entries = {}
 def run_entrypoints():
     entries.clear()
     eps = entry_points()
-    if hasattr(eps, 'select'):
-        # If entry_points() has a select method, use that. Python 3.10+
-        entries.update({e.name: e for e in eps.select(group="numcodecs.codecs")})
-    else:
-        # Otherwise, fallback to using get
-        entries.update({e.name: e for e in eps.get("numcodecs.codecs", [])})
+    entries.update({e.name: e for e in eps.select(group="numcodecs.codecs")})
 
 
 run_entrypoints()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme =  "README.rst"
 dependencies = [
     "numpy>=1.7,<2",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dynamic = [
   "version",
 ]


### PR DESCRIPTION
As per [SPEC 0](https://scientific-python.org/specs/spec-0000/) (which it says that zarr is signed up to), drop support from Python 3.8/3.9.
