### PR TITLE
Add numpy 2.0 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,14 @@ jobs:
           # TODO: put back zfpy import when it supports numpy 2.0
           python -m pip install -v -e .[test,test_extras,msgpack,pcodec]
 
+      # This is used to test with zfpy, which does not yet support numpy 2.0
+      - name: Install older numpy and zfpy
+        if: ${{ matrix.python-version }} == '3.10'
+        shell: "bash -l {0}"
+        run: |
+          conda activate env
+          python -m pip install zfpy>1 numpy<2
+
       - name: List installed packages
         shell: "bash -l {0}"
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install clang
         shell: "bash -l {0}"
-        if: ${{ matrix.platform }} == 'macos-12'
+        if: matrix.platform == 'macos-12'
         run: |
           conda activate env
           conda install -y 'clang>=12.0.1,<17'
@@ -64,7 +64,7 @@ jobs:
 
       # This is used to test with zfpy, which does not yet support numpy 2.0
       - name: Install older numpy and zfpy
-        if: ${{ matrix.python-version }} == '3.10'
+        if: matrix.python-version == '3.10'
         shell: "bash -l {0}"
         run: |
           conda activate env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,8 @@ jobs:
         run: |
           conda activate env
           export DISABLE_NUMCODECS_AVX2=""
-          python -m pip install -v -e .[test,test_extras,msgpack,zfpy,pcodec]
+          # TODO: put back zfpy import when it supports numpy 2.0
+          python -m pip install -v -e .[test,test_extras,msgpack,pcodec]
 
       - name: List installed packages
         shell: "bash -l {0}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         shell: "bash -l {0}"
         run: |
           conda activate env
-          python -m pip install zfpy>1 numpy<2
+          python -m pip install "zfpy>1" "numpy<2"
 
       - name: List installed packages
         shell: "bash -l {0}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         shell: "bash -l {0}"
         run: |
           conda activate env
-          python -m pip install "zfpy>1" "numpy<2"
+          python -m pip install "zfpy>=1" "numpy<2"
 
       - name: List installed packages
         shell: "bash -l {0}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ A Python package providing buffer compression and transformation codecs \
 for use in data storage and communication applications."""
 readme =  "README.rst"
 dependencies = [
-    "numpy>=1.7,<2",
+    "numpy>=1.7",
 ]
 requires-python = ">=3.10"
 dynamic = [


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/numcodecs/issues/521.

Currently the solution is to just test without zfpy support, which is easy to implement. In an ideaL world I guess we want to run at least one test with zfpy and `numpy<2`? I won't have time to implement that in the next few days, so someone else feel free to take over and do that if desirable.
