### PR TITLE
Fix ZFPY import error

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -31,6 +31,8 @@ Fix
   By :user:`Elliott Sales de Andrade <QuLogic>`, :issue:`487`.
 * Fix Upgrade to Zstd 1.5.5 due to potential corruption.
   By :user:`Mark Kittisopikul <mkitti>`, :issue:`429`
+* Add version constraint(<2.0) for numpy in zfpy.
+  By :user:`Tom Liang <px39n>`, :issue:540.
 
 Maintenance
 ~~~~~~~~~~~

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -32,7 +32,7 @@ Fix
 * Fix Upgrade to Zstd 1.5.5 due to potential corruption.
   By :user:`Mark Kittisopikul <mkitti>`, :issue:`429`
 * Add version constraint(<2.0) for numpy in zfpy.
-  By :user:`Tom Liang <px39n>`, :issue:540.
+  By :user:`Tom Liang <px39n>`, :issue:`540`.
 
 Maintenance
 ~~~~~~~~~~~

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -11,7 +11,7 @@ with suppress(PackageNotFoundError):
 if _zfpy_version:
     # Check NumPy version
     _numpy_version: tuple = tuple(map(int, version("numpy").split('.')))
-    if numpy_version_tuple >= (2, 0, 0) and zfpy_version_tuple <= (1, 0, 1):
+    if _numpy_version >= (2, 0, 0) and _zfpy_version <= (1, 0, 1):
         _zfpy_version = ()
         warnings.warn(
             "NumPy version >= 2.0.0 detected. The zfpy library is incompatible with this version of NumPy. "

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -16,11 +16,11 @@ if _zfpy_version:
         warnings.warn(
             "NumPy version >= 2.0.0 detected. The zfpy library is incompatible with this version of NumPy. "
             "Please downgrade to NumPy < 2.0.0 or wait for an update from zfpy.",
-            UserWarning
+            UserWarning,
         )
 else:
     with suppress(ImportError):
-        import zfpy as _zfpy 
+        import zfpy as _zfpy
 
 if _zfpy:
     from .abc import Codec

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -4,16 +4,20 @@ import warnings
 
 _zfpy = None
 
-# Check NumPy version
-numpy_version = np.__version__
-numpy_version_tuple = tuple(map(int, numpy_version.split('.')))
-if numpy_version_tuple >= (2, 0, 0):
-    _zfpy = None
-    warnings.warn(
-        "NumPy version >= 2.0.0 detected. The zfpy library is incompatible with this version of NumPy. "
-        "Please downgrade to NumPy < 2.0.0 or wait for an update from zfpy.",
-        UserWarning
-    )
+_zfpy_version: tuple = ()
+with suppress(PackageNotFoundError):
+    _zfpy_version = tuple(map(int, version("zfpy").split(".")))
+
+if _zfpy_version:
+    # Check NumPy version
+    _numpy_version: tuple = tuple(map(int, version("numpy").split('.')))
+    if numpy_version_tuple >= (2, 0, 0) and zfpy_version_tuple <= (1, 0, 1):
+        _zfpy_version = ()
+        warnings.warn(
+            "NumPy version >= 2.0.0 detected. The zfpy library is incompatible with this version of NumPy. "
+            "Please downgrade to NumPy < 2.0.0 or wait for an update from zfpy.",
+            UserWarning
+        )
 else:
     with suppress(ImportError):
         import zfpy as _zfpy 

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -16,7 +16,7 @@ if numpy_version_tuple >= (2, 0, 0):
     )
 else:
     with suppress(ImportError):
-    import zfpy as _zfpy 
+        import zfpy as _zfpy 
 
 if _zfpy:
     from .abc import Codec

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -18,9 +18,9 @@ if _zfpy_version:
             "Please downgrade to NumPy < 2.0.0 or wait for an update from zfpy.",
             UserWarning,
         )
-else:
-    with suppress(ImportError):
-        import zfpy as _zfpy
+    else:
+        with suppress(ImportError):
+            import zfpy as _zfpy
 
 if _zfpy:
     from .abc import Codec

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -1,6 +1,6 @@
 from contextlib import suppress
+from importlib.metadata import PackageNotFoundError, version
 import warnings
-import numpy as np
 
 _zfpy = None
 

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -1,9 +1,22 @@
 from contextlib import suppress
+import warnings
+import numpy as np
 
 _zfpy = None
-with suppress(ImportError):
-    import zfpy as _zfpy
 
+# Check NumPy version
+numpy_version = np.__version__
+numpy_version_tuple = tuple(map(int, numpy_version.split('.')))
+if numpy_version_tuple >= (2, 0, 0):
+    _zfpy = None
+    warnings.warn(
+        "NumPy version >= 2.0.0 detected. The zfpy library is incompatible with this version of NumPy. "
+        "Please downgrade to NumPy < 2.0.0 or wait for an update from zfpy.",
+        UserWarning
+    )
+else:
+    with suppress(ImportError):
+    import zfpy as _zfpy 
 
 if _zfpy:
     from .abc import Codec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ A Python package providing buffer compression and transformation codecs \
 for use in data storage and communication applications."""
 readme =  "README.rst"
 dependencies = [
-    "numpy>=1.7",
+    "numpy>=1.7, <2.0",
 ]
 requires-python = ">=3.10"
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ A Python package providing buffer compression and transformation codecs \
 for use in data storage and communication applications."""
 readme =  "README.rst"
 dependencies = [
-    "numpy>=1.7, <2.0",
+    "numpy>=1.7",
 ]
 requires-python = ">=3.10"
 dynamic = [
@@ -64,6 +64,7 @@ msgpack = [
 ]
 zfpy = [
     "zfpy>=1.0.0",
+    "numpy<2.0.0",    
 ]
 pcodec = [
     "pcodec>=0.1.0",


### PR DESCRIPTION
When 

numpy >=2.0.0
from numcodecs.zfpy import ZFPY

raise error [ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject]


The error is caused by zfpy library crashing with recent ABI breaking of numpy udpate. So we'd better force numpy <2.0 unless zfpy update again.


Reference: (https://stackoverflow.com/questions/66060487/valueerror-numpy-ndarray-size-changed-may-indicate-binary-incompatibility-exp)

[Description of PR]

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
