### PR TITLE
Fixed setup commands in contributing doc

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -92,8 +92,8 @@ Creating a development environment
 To work with the NumCodecs source code, it is recommended to set up a Python virtual
 environment and install all NumCodecs dependencies using the same versions as are used by
 the core developers and continuous integration services. Assuming you have a Python
-3 interpreter matching [the `requires-python` constraint](../pyproject.toml)
-already installed, and you have cloned the NumCodecs source code and your
+3 interpreter already installed matching the ``requires-python`` constraint from
+``pyproject.toml``, and you have cloned the NumCodecs source code and your
 current working directory is the root of the repository, you can do something
 like the following::
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -92,12 +92,12 @@ Creating a development environment
 To work with the NumCodecs source code, it is recommended to set up a Python virtual
 environment and install all NumCodecs dependencies using the same versions as are used by
 the core developers and continuous integration services. Assuming you have a Python
-3 interpreter already installed, and have also installed the virtualenv package, and
-you have cloned the NumCodecs source code and your current working directory is the root of
-the repository, you can do something like the following::
+3 interpreter matching [the `requires-python` constraint](../pyproject.toml)
+already installed, and you have cloned the NumCodecs source code and your
+current working directory is the root of the repository, you can do something
+like the following::
 
-    $ mkdir -p ~/pyenv/numcodecs-dev
-    $ virtualenv --no-site-packages --python=/usr/bin/python3.9 ~/pyenv/numcodecs-dev
+    $ python3 -m venv ~/pyenv/numcodecs-dev
     $ source ~/pyenv/numcodecs-dev/bin/activate
     $ pip install -e .[docs,test,msgpack,zfpy]
 


### PR DESCRIPTION
Previously they pointed to 3.9, which failed due to the version constraint and bad dependency resolution. This change points to pyproject.toml to be more future-proof.