### PR TITLE
Only suppress imports of optional external dependencies

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -24,6 +24,14 @@ Fixes
 
 Improvements
 ~~~~~~~~~~~~
+* If an import error is raised when trying to define a codec that is *not*
+  an optional dependency, it is no longer silently caught. Instead it will
+  be propagated to the user, as this indicates an issue with the installed
+  package.
+
+  Import errors caused by optional dependencies (ZFPY, MsgPack, CRC32C, and PCodec)
+  are still silently caught.
+  By :user:`David Stansby <dstansby>`, :issue:`550`.
 
 
 0.14.1

--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -114,7 +114,7 @@ from numcodecs.json import JSON
 register_codec(JSON)
 
 from numcodecs import vlen as vlen
-from numcodecs.vlen import VLenUTF8, VLenBytes, VLenArray
+from numcodecs.vlen import VLenArray, VLenBytes, VLenUTF8
 
 register_codec(VLenUTF8)
 register_codec(VLenBytes)

--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -36,37 +36,34 @@ from numcodecs.bz2 import BZ2
 
 register_codec(BZ2)
 
-with suppress(ImportError):
-    from numcodecs.lzma import LZMA
+from numcodecs.lzma import LZMA
 
-    register_codec(LZMA)
+register_codec(LZMA)
 
-with suppress(ImportError):
-    from numcodecs import blosc
-    from numcodecs.blosc import Blosc
+from numcodecs import blosc
+from numcodecs.blosc import Blosc
 
-    register_codec(Blosc)
-    # initialize blosc
-    try:
-        ncores = multiprocessing.cpu_count()
-    except OSError:  # pragma: no cover
-        ncores = 1
-    blosc.init()
-    blosc.set_nthreads(min(8, ncores))
-    atexit.register(blosc.destroy)
+register_codec(Blosc)
+# initialize blosc
+try:
+    ncores = multiprocessing.cpu_count()
+except OSError:  # pragma: no cover
+    ncores = 1
+blosc.init()
+blosc.set_nthreads(min(8, ncores))
+atexit.register(blosc.destroy)
 
-with suppress(ImportError):
-    from numcodecs import zstd as zstd
-    from numcodecs.zstd import Zstd
+from numcodecs import zstd as zstd
+from numcodecs.zstd import Zstd
 
-    register_codec(Zstd)
+register_codec(Zstd)
 
-with suppress(ImportError):
-    from numcodecs import lz4 as lz4
-    from numcodecs.lz4 import LZ4
+from numcodecs import lz4 as lz4
+from numcodecs.lz4 import LZ4
 
-    register_codec(LZ4)
+register_codec(LZ4)
 
+# zfpy is an optional external dependency
 with suppress(ImportError):
     from numcodecs.zfpy import ZFPY
 
@@ -112,6 +109,7 @@ from numcodecs.bitround import BitRound
 
 register_codec(BitRound)
 
+# msgpack is an optional external dependency
 with suppress(ImportError):
     from numcodecs.msgpacks import MsgPack
 
@@ -132,18 +130,19 @@ from numcodecs.json import JSON
 
 register_codec(JSON)
 
-with suppress(ImportError):
-    from numcodecs import vlen as vlen
-    from numcodecs.vlen import VLenArray, VLenBytes, VLenUTF8
+from numcodecs import vlen as vlen
+from numcodecs.vlen import VLenUTF8, VLenBytes, VLenArray
 
-    register_codec(VLenUTF8)
-    register_codec(VLenBytes)
-    register_codec(VLenArray)
+register_codec(VLenUTF8)
+register_codec(VLenBytes)
+register_codec(VLenArray)
 
 from numcodecs.fletcher32 import Fletcher32
 
 register_codec(Fletcher32)
 
-from numcodecs.pcodec import PCodec
+# pcodec is an optional external dependency
+with suppress(ImportError):
+    from numcodecs.pcodec import PCodec
 
-register_codec(PCodec)
+    register_codec(PCodec)

--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -63,12 +63,6 @@ from numcodecs.lz4 import LZ4
 
 register_codec(LZ4)
 
-# zfpy is an optional external dependency
-with suppress(ImportError):
-    from numcodecs.zfpy import ZFPY
-
-    register_codec(ZFPY)
-
 from numcodecs.astype import AsType
 
 register_codec(AsType)
@@ -109,22 +103,11 @@ from numcodecs.bitround import BitRound
 
 register_codec(BitRound)
 
-# msgpack is an optional external dependency
-with suppress(ImportError):
-    from numcodecs.msgpacks import MsgPack
-
-    register_codec(MsgPack)
-
 from numcodecs.checksum32 import CRC32, Adler32, JenkinsLookup3
 
 register_codec(CRC32)
 register_codec(Adler32)
 register_codec(JenkinsLookup3)
-
-with suppress(ImportError):
-    from numcodecs.checksum32 import CRC32C
-
-    register_codec(CRC32C)
 
 from numcodecs.json import JSON
 
@@ -141,7 +124,22 @@ from numcodecs.fletcher32 import Fletcher32
 
 register_codec(Fletcher32)
 
-# pcodec is an optional external dependency
+# Optional depenedencies
+with suppress(ImportError):
+    from numcodecs.zfpy import ZFPY
+
+    register_codec(ZFPY)
+
+with suppress(ImportError):
+    from numcodecs.msgpacks import MsgPack
+
+    register_codec(MsgPack)
+
+with suppress(ImportError):
+    from numcodecs.checksum32 import CRC32C
+
+    register_codec(CRC32C)
+
 with suppress(ImportError):
     from numcodecs.pcodec import PCodec
 


### PR DESCRIPTION
This makes the suppression of import errors consistent with which codecs depend on optional external packages. If a codec doesn't depend on any code external to `numcodecs`, then import errors shouldn't be suppressed as they are indicating an issue with `numcodecs` itself.

I looked in `git blame` and there doesn't seem to be any commentary/reason given for these suppressions, and they all seem to have been added in the original PRs where each codec was added.

This came up over at https://github.com/zarr-developers/zarr-python/issues/2032.