### PR TITLE
Rewrite logic in `vlen` to drop NumPy build dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,13 +196,12 @@ def lz4_extension():
 
 def vlen_extension():
     info('setting up vlen extension')
-    import numpy
 
     extra_compile_args = base_compile_args.copy()
     define_macros = []
 
     # setup sources
-    include_dirs = ['numcodecs', numpy.get_include()]
+    include_dirs = ['numcodecs']
     # define_macros += [('CYTHON_TRACE', '1')]
 
     sources = ['numcodecs/vlen.pyx']


### PR DESCRIPTION
As noted in issue ( https://github.com/zarr-developers/numcodecs ), `vlen` had problems with read-only data

Internally this occurred because we assigned the input array to `object[:]`, which expects mutability. Ideally we would just replace this with `const object[:]`. However Cython does not support this ( https://github.com/cython/cython/issues/2485 ). Over time various blockers have been resolved on that front, but it is not yet fixed

Fortunately an astute SciPy developer noted that `const <fused_type>[:]` is allowed ( https://github.com/scipy/scipy/pull/18192#pullrequestreview-1359581611 ). We use that same trick here

This in turn should allow us to continue to accept read-only arrays. Though this does so without a NumPy build dependency, which can introduce more complexity to the build process

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
