### PR TITLE
Revert "Allow VLenUTF8 to encode a read-only source"

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -39,8 +39,7 @@ Enhancements
 
 Fix
 ~~~
-* Fix VLenUTF8 encoding for read-only buffers.
-  By :user:`Isaac Virshup <ivirshup>`, :issue:`514`.
+
 * Fix skip of entry points backport tests
   By :user:`Elliott Sales de Andrade <QuLogic>`, :issue:`487`.
 * Fix Upgrade to Zstd 1.5.5 due to potential corruption.

--- a/numcodecs/tests/test_vlen_utf8.py
+++ b/numcodecs/tests/test_vlen_utf8.py
@@ -82,11 +82,8 @@ def test_decode_errors():
         codec.decode(enc, out=np.zeros(10, dtype='i4'))
 
 
-@pytest.mark.parametrize("writable", [True, False])
-def test_encode_utf8(writable):
+def test_encode_utf8():
     a = np.array(['foo', None, 'bar'], dtype=object)
-    if not writable:
-        a.setflags(write=False)
     codec = VLenUTF8()
     enc = codec.encode(a)
     dec = codec.decode(enc)

--- a/numcodecs/vlen.pyx
+++ b/numcodecs/vlen.pyx
@@ -7,7 +7,6 @@
 
 import cython
 cimport cython
-from numpy cimport ndarray
 import numpy as np
 from .abc import Codec
 from .compat_ext cimport Buffer
@@ -75,7 +74,7 @@ class VLenUTF8(Codec):
     def encode(self, buf):
         cdef:
             Py_ssize_t i, l, n_items, data_length, total_length
-            ndarray[object, ndim=1] input_values
+            object[:] input_values
             object[:] encoded_values
             int[:] encoded_lengths
             char* encv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,7 @@ requires = [
     "setuptools>=64",
     "setuptools-scm[toml]>=6.2",
     "Cython",
-    "py-cpuinfo",
-    "numpy",
+    "py-cpuinfo"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -196,13 +196,12 @@ def lz4_extension():
 
 def vlen_extension():
     info('setting up vlen extension')
-    import numpy
 
     extra_compile_args = base_compile_args.copy()
     define_macros = []
 
     # setup sources
-    include_dirs = ['numcodecs', numpy.get_include()]
+    include_dirs = ['numcodecs']
     # define_macros += [('CYTHON_TRACE', '1')]
 
     sources = ['numcodecs/vlen.pyx']


### PR DESCRIPTION
Reverts zarr-developers/numcodecs#515, as discussed in https://github.com/conda-forge/numcodecs-feedstock/pull/107#issuecomment-2270007816.