### PR TITLE
adds round_to_int boolean argument to FixedScaleOffset

### DIFF
--- a/numcodecs/fixedscaleoffset.py
+++ b/numcodecs/fixedscaleoffset.py
@@ -8,7 +8,7 @@ from .compat import ensure_ndarray, ndarray_copy
 class FixedScaleOffset(Codec):
     """Simplified version of the scale-offset filter available in HDF5.
     Applies the transformation `(x - offset) * scale` to all chunks. Results
-    are rounded to the nearest integer but are not packed according to the
+    are optionally rounded to the nearest integer but are not packed according to the
     minimum number of bits.
 
     Parameters
@@ -21,6 +21,8 @@ class FixedScaleOffset(Codec):
         Data type to use for decoded data.
     astype : dtype, optional
         Data type to use for encoded data.
+    round_to_int : boolean
+        Flag to control rounding encoded data to integers after applying scale and offset
 
     Notes
     -----
@@ -70,10 +72,11 @@ class FixedScaleOffset(Codec):
 
     codec_id = 'fixedscaleoffset'
 
-    def __init__(self, offset, scale, dtype, astype=None):
+    def __init__(self, offset, scale, dtype, astype=None, round_to_int=True):
         self.offset = offset
         self.scale = scale
         self.dtype = np.dtype(dtype)
+        self.round_to_int = round_to_int
         if astype is None:
             self.astype = self.dtype
         else:
@@ -91,8 +94,9 @@ class FixedScaleOffset(Codec):
         # compute scale offset
         enc = (arr - self.offset) * self.scale
 
-        # round to nearest integer
-        enc = np.around(enc)
+        if self.round_to_int:
+            # round to nearest integer
+            enc = np.around(enc)
 
         # convert dtype
         enc = enc.astype(self.astype, copy=False)

--- a/numcodecs/tests/test_fixedscaleoffset.py
+++ b/numcodecs/tests/test_fixedscaleoffset.py
@@ -2,7 +2,7 @@ import itertools
 
 
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 import pytest
 
 
@@ -30,6 +30,7 @@ codecs = [
     FixedScaleOffset(offset=1000, scale=10**6, dtype='<f8', astype='<i4'),
     FixedScaleOffset(offset=1000, scale=10**12, dtype='<f8', astype='<i8'),
     FixedScaleOffset(offset=1000, scale=10**12, dtype='<f8'),
+    FixedScaleOffset(offset=1000, scale=10**12, dtype='<f8', round_to_int=False),
 ]
 
 
@@ -49,6 +50,14 @@ def test_encode():
     assert_array_equal(expect, actual)
     assert np.dtype(astype) == actual.dtype
 
+def test_encode_no_round():
+    dtype = '<f8'
+    astype = dtype
+    codec = FixedScaleOffset(scale=1, offset=1000, dtype=dtype, astype=astype, round_to_int=False)
+    arr = np.linspace(1000, 1001, 10, dtype=dtype)
+    expect = np.linspace(0, 1, 10, dtype=dtype)
+    actual = codec.encode(arr)
+    assert_allclose(expect, actual)
 
 def test_config():
     codec = FixedScaleOffset(dtype='<f8', astype='<i4', scale=10, offset=100)

--- a/numcodecs/tests/test_fixedscaleoffset.py
+++ b/numcodecs/tests/test_fixedscaleoffset.py
@@ -50,6 +50,7 @@ def test_encode():
     assert_array_equal(expect, actual)
     assert np.dtype(astype) == actual.dtype
 
+
 def test_encode_no_round():
     dtype = '<f8'
     astype = dtype
@@ -58,6 +59,7 @@ def test_encode_no_round():
     expect = np.linspace(0, 1, 10, dtype=dtype)
     actual = codec.encode(arr)
     assert_allclose(expect, actual)
+
 
 def test_config():
     codec = FixedScaleOffset(dtype='<f8', astype='<i4', scale=10, offset=100)


### PR DESCRIPTION
Makes it possible to apply this filter without automatically converting to integers. #549
