### PR TITLE
Build aarch64 wheels

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -8,17 +8,22 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: Build wheel on ${{ matrix.os }}
+    name: Build ${{ matrix.archs }} wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is a arm64 runner
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        archs: ["native"]
+        include:
+          - os: ubuntu-latest
+            archs: "aarch64"
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"
       CIBW_BUILD: "cp311-* cp312-* cp313-*"
       CIBW_SKIP: "pp* *-musllinux_* *win32 *_i686 *_s390x"
+      CIBW_ARCHS: ${{ matrix.archs }}
       # note: CIBW_ENVIRONMENT is now set in pyproject.toml
 
     steps:

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -8,22 +8,21 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: Build ${{ matrix.archs }} wheel on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is a arm64 runner
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
-        archs: ["native"]
-        include:
-          - os: ubuntu-latest
-            archs: "aarch64"
+        build_all:
+          - ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')) || contains(github.event.pull_request.labels.*.name, 'test all wheels')}}
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"
       CIBW_BUILD: "cp311-* cp312-* cp313-*"
-      CIBW_SKIP: "pp* *-musllinux_* *win32 *_i686 *_s390x"
-      CIBW_ARCHS: ${{ matrix.archs }}
+      CIBW_ARCHS_MACOS: native
+      CIBW_ARCHS_WINDOWS: native
+      CIBW_ARCHS_LINUX: "x86_64 aarch64"
       # note: CIBW_ENVIRONMENT is now set in pyproject.toml
 
     steps:
@@ -31,11 +30,16 @@ jobs:
         with:
           submodules: true
 
-      - uses: pypa/cibuildwheel@v2.22.0
+      - name: Restrict number of wheel builds on PRs
+        if: ${{ !matrix.build_all }}
+        run: |
+          echo "CIBW_BUILD=cp310-win_amd64 cp311-manylinux_x86_64 cp312-macosx_x86_64 cp312-macosx_arm64" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        if: ${{ matrix.archs == 'aarch64' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: docker/setup-qemu-action@v3
+
+      - uses: pypa/cibuildwheel@v2.22.0
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -6,6 +6,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Build all wheels on either:
+  #    - tagged release
+  #    - pull request opened with "test all wheels" label
+  #    - pull requests when "test all wheels" label is added
+  BUILD_ALL: |
+    ${{
+        (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))
+        || contains(github.event.pull_request.labels.*.name, 'test all wheels')
+        || (github.event.action == 'labeled' && github.event.label.name == 'test all wheels')
+    }}
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -15,16 +27,6 @@ jobs:
       matrix:
         # macos-13 is an intel runner, macos-14 is a arm64 runner
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
-        # Build all wheels on either:
-        #    - tagged release
-        #    - pull request opened with "test all wheels" label
-        #    - pull requests when "test all wheels" label is added
-        build_all: |
-          ${{
-              (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))
-              || contains(github.event.pull_request.labels.*.name, 'test all wheels')
-              || (github.event.action == 'labeled' && github.event.label.name == 'test all wheels')
-          }}
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"
       CIBW_BUILD: "cp311-* cp312-* cp313-*"
@@ -39,7 +41,7 @@ jobs:
           submodules: true
 
       - name: Restrict number of wheel builds on PRs
-        if: ${{ !matrix.build_all }}
+        if: ${{ !env.BUILD_ALL }}
         run: |
           echo "CIBW_BUILD=cp310-win_amd64 cp311-manylinux_x86_64 cp312-macosx_x86_64 cp312-macosx_arm64" >> $GITHUB_ENV
 

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -33,6 +33,10 @@ jobs:
 
       - uses: pypa/cibuildwheel@v2.22.0
 
+      - name: Set up QEMU
+        if: ${{ matrix.archs == 'aarch64' }}
+        uses: docker/setup-qemu-action@v3
+
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -15,8 +15,16 @@ jobs:
       matrix:
         # macos-13 is an intel runner, macos-14 is a arm64 runner
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
-        build_all:
-          - ${{ (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')) || contains(github.event.pull_request.labels.*.name, 'test all wheels')}}
+        # Build all wheels on either:
+        #    - tagged release
+        #    - pull request opened with "test all wheels" label
+        #    - pull requests when "test all wheels" label is added
+        build_all: |
+          ${{
+              (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))
+              || contains(github.event.pull_request.labels.*.name, 'test all wheels')
+              || (github.event.action == 'labeled' && github.event.label.name == 'test all wheels')
+          }}
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"
       CIBW_BUILD: "cp311-* cp312-* cp313-*"

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -43,7 +43,8 @@ Improvements
   Import errors caused by optional dependencies (ZFPY, MsgPack, CRC32C, and PCodec)
   are still silently caught.
   By :user:`David Stansby <dstansby>`, :issue:`550`.
-
+* Build aarch64 wheels on linux.
+  By :user:`David Stansby <dstansby>`, :issue:`531`
 
 0.14.1
 ------
@@ -116,12 +117,23 @@ Enhancements
 * Cleaned up the table of contents in the documentation to list codecs by category
   :user:`David Stansby <dstansby>`, :issue:`458`.
 
+Fix
+~~~
+
+
 Maintenance
 ~~~~~~~~~~~
 * Change format() and old string formatting to f-strings.
   By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`439`.
 * Remove pin on Sphinx
   By :user:`Elliott Sales de Andrade <QuLogic>`, :issue:`552`.
+
+* Restrict the number of wheels built on pull requests.
+  By :user:`David Stansby <dstansby>`, :issue:`531`
+
+* Add an option to build all wheels on pull requests by adding
+  the 'build all wheels' label.
+  By :user:`David Stansby <dstansby>`, :issue:`531`
 
 
 .. _release_0.13.0:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,9 @@ base_compile_args = []
 if have_cflags:
     # respect compiler options set by user
     pass
-elif os.name == 'posix':
+elif os.name == 'posix' and os.uname()[4] != 'aarch64':
+    # These flags aren't recognised by gcc on aarch64
+    # (at least when we build the aarch64 wheens on GitHub actions)
     if disable_sse2:
         base_compile_args.append('-mno-sse2')
     elif have_sse2:


### PR DESCRIPTION
This PR:

- Changes the cibuildwheel config to explicitly list the architectures to build for
- Adds `aarch64` to this list for linux builds
- Restricts the number of wheels built on a PR to 1 per major platform (linux, windows, macOS x86_64, macOS arm64)
- Builds all the wheels on release, or when the "build all wheels" label is added to a PR

This speeds up runs on PRs, but allows the flexibiility of doing a full run of wheel building if needed by adding the label.

Fixes https://github.com/zarr-developers/numcodecs/issues/312, fixes https://github.com/zarr-developers/numcodecs/issues/288, and an updated version of https://github.com/zarr-developers/numcodecs/pull/315



TODO:

- [x] Changes documented in docs/release.rst
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
