### PR TITLE
Apply ruff/pyupgrade rule UP032 to notebooks

### DIFF
--- a/notebooks/benchmark_vlen.ipynb
+++ b/notebooks/benchmark_vlen.ipynb
@@ -55,10 +55,10 @@
     "    enc = codec.encode(a)\n",
     "    print('decode')\n",
     "    %timeit codec.decode(enc)\n",
-    "    print('size         : {:,}'.format(len(enc)))\n",
-    "    print('size (zstd 1): {:,}'.format(len(zstd1.encode(enc))))\n",
-    "    print('size (zstd 5): {:,}'.format(len(zstd5.encode(enc))))\n",
-    "    print('size (zstd 9): {:,}'.format(len(zstd9.encode(enc))))"
+    "    print(f'size         : {len(enc):,}')\n",
+    "    print(f'size (zstd 1): {len(zstd1.encode(enc)):,}')\n",
+    "    print(f'size (zstd 5): {len(zstd5.encode(enc)):,}')\n",
+    "    print(f'size (zstd 9): {len(zstd9.encode(enc)):,}')"
    ]
   },
   {


### PR DESCRIPTION
UP032 Use f-string instead of `format` call

Starting with ruff 0.6, ruff also lints notebooks.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
