### PR TITLE
Apply normalization consistently in VLenBytes

### DIFF
--- a/numcodecs/vlen.pyx
+++ b/numcodecs/vlen.pyx
@@ -250,7 +250,10 @@ class VLenBytes(Codec):
             l = lengths[i]
             store_le32(<uint8_t*>data, l)
             data += 4
-            encv = PyBytes_AS_STRING(values[i])
+            b = values[i]
+            if b is None or b == 0:  # treat these as missing value, normalize
+                b = b''
+            encv = PyBytes_AS_STRING(b)
             memcpy(data, encv, l)
             data += l
 


### PR DESCRIPTION
None and 0 are treated like a 0 length string when computing lengths, and the same normalization should be applied to the value passed to PyBytes_AS_STRING. If this is not done, an assertion is hit in the python runtime (when compiled in debug mode).

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
