### PR TITLE
Update optimized `Delta` codec for `bool`

### DIFF
--- a/numcodecs/delta.py
+++ b/numcodecs/delta.py
@@ -65,9 +65,9 @@ class Delta(Codec):
         # compute differences
         # using np.subtract for in-place operations
         if arr.dtype == bool:
-            np.not_equal(arr[1:], arr[0:-1], out=enc[1:])
+            np.not_equal(arr[1:], arr[:-1], out=enc[1:])
         else:
-            np.subtract(arr[1:], arr[0:-1], out=enc[1:])
+            np.subtract(arr[1:], arr[:-1], out=enc[1:])
 
         return enc
 

--- a/numcodecs/delta.py
+++ b/numcodecs/delta.py
@@ -64,7 +64,10 @@ class Delta(Codec):
 
         # compute differences
         # using np.subtract for in-place operations
-        np.subtract(arr[1:], arr[0:-1], out=enc[1:])
+        if self.dtype == np.dtype("bool"):
+            np.not_equal(arr[1:], arr[0:-1], out=enc[1:])
+        else:
+            np.subtract(arr[1:], arr[0:-1], out=enc[1:])
 
         return enc
 

--- a/numcodecs/delta.py
+++ b/numcodecs/delta.py
@@ -64,7 +64,7 @@ class Delta(Codec):
 
         # compute differences
         # using np.subtract for in-place operations
-        if self.dtype == np.dtype("bool"):
+        if arr.dtype == bool:
             np.not_equal(arr[1:], arr[0:-1], out=enc[1:])
         else:
             np.subtract(arr[1:], arr[0:-1], out=enc[1:])

--- a/numcodecs/tests/test_delta.py
+++ b/numcodecs/tests/test_delta.py
@@ -14,6 +14,7 @@ from numcodecs.tests.common import (
 # mix of shapes: 1D, 2D, 3D
 # mix of orders: C, F
 arrays = [
+    np.random.randint(0, 1, size=110, dtype='?').reshape(10, 11),
     np.arange(1000, dtype='<i4'),
     np.linspace(1000, 1001, 1000, dtype='<f4').reshape(100, 10),
     np.random.normal(loc=1000, scale=1, size=(10, 10, 10)).astype('<f8'),


### PR DESCRIPTION
Previously `bool` just worked with `Delta`. However this was not actually tested. The optimized version switched to `np.subtract` for in-place computation, which works for other types. Though `bool` needs special handling. Fortunately this can be done with `np.not_equal`, which has the same behavior.

Also include a test for `bool` data to make sure this is handled correctly going forward.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
