### PR TITLE
Sync with zarr 3 beta

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
         shell: "bash -l {0}"
         run: |
           conda activate env
-          python -m pip install zarr==3.0.0a0
+          python -m pip install zarr==3.0.0b0
 
       # This is used to test with zfpy, which does not yet support numpy 2.0
       - name: Install older numpy and zfpy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
           python -m pip install -v -e .[test,test_extras,msgpack,pcodec]
 
       - name: Install zarr-python
+        if : matrix.python-version != '3.10'
         shell: "bash -l {0}"
         run: |
           conda activate env

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, replace
 from functools import cached_property
 import math
@@ -17,15 +18,15 @@ except ImportError:
     raise ImportError("zarr 3.0.0 or later is required to use the numcodecs zarr integration.")
 
 from zarr.abc.codec import ArrayArrayCodec, BytesBytesCodec, ArrayBytesCodec
-from zarr.buffer import NDBuffer, Buffer, BufferPrototype, as_numpy_array_wrapper
-from zarr.array_spec import ArraySpec
-from zarr.common import (
+from zarr.core.buffer import NDBuffer, Buffer, BufferPrototype
+from zarr.core.buffer.cpu import as_numpy_array_wrapper
+from zarr.core.array_spec import ArraySpec
+from zarr.core.common import (
     JSON,
     parse_named_configuration,
     product,
-    to_thread,
 )
-from zarr.metadata import ArrayMetadata
+from zarr.core.metadata import ArrayMetadata
 
 
 CODEC_PREFIX = "numcodecs."
@@ -90,7 +91,7 @@ class NumcodecsBytesBytesCodec(NumcodecsCodec, BytesBytesCodec):
         super().__init__(codec_id=codec_id, codec_config=codec_config)
 
     async def _decode_single(self, chunk_bytes: Buffer, chunk_spec: ArraySpec) -> Buffer:
-        return await to_thread(
+        return await asyncio.to_thread(
             as_numpy_array_wrapper,
             self._codec.decode,
             chunk_bytes,
@@ -104,7 +105,7 @@ class NumcodecsBytesBytesCodec(NumcodecsCodec, BytesBytesCodec):
         return prototype.buffer.from_bytes(encoded)
 
     async def _encode_single(self, chunk_bytes: Buffer, chunk_spec: ArraySpec) -> Buffer:
-        return await to_thread(self._encode, chunk_bytes, chunk_spec.prototype)
+        return await asyncio.to_thread(self._encode, chunk_bytes, chunk_spec.prototype)
 
 
 class NumcodecsArrayArrayCodec(NumcodecsCodec, ArrayArrayCodec):
@@ -113,12 +114,12 @@ class NumcodecsArrayArrayCodec(NumcodecsCodec, ArrayArrayCodec):
 
     async def _decode_single(self, chunk_array: NDBuffer, chunk_spec: ArraySpec) -> NDBuffer:
         chunk_ndarray = chunk_array.as_ndarray_like()
-        out = await to_thread(self._codec.decode, chunk_ndarray)
+        out = await asyncio.to_thread(self._codec.decode, chunk_ndarray)
         return chunk_spec.prototype.nd_buffer.from_ndarray_like(out.reshape(chunk_spec.shape))
 
     async def _encode_single(self, chunk_array: NDBuffer, chunk_spec: ArraySpec) -> NDBuffer:
         chunk_ndarray = chunk_array.as_ndarray_like()
-        out = await to_thread(self._codec.encode, chunk_ndarray)
+        out = await asyncio.to_thread(self._codec.encode, chunk_ndarray)
         return chunk_spec.prototype.nd_buffer.from_ndarray_like(out)
 
 
@@ -128,12 +129,12 @@ class NumcodecsArrayBytesCodec(NumcodecsCodec, ArrayBytesCodec):
 
     async def _decode_single(self, chunk_buffer: Buffer, chunk_spec: ArraySpec) -> NDBuffer:
         chunk_bytes = chunk_buffer.to_bytes()
-        out = await to_thread(self._codec.decode, chunk_bytes)
+        out = await asyncio.to_thread(self._codec.decode, chunk_bytes)
         return chunk_spec.prototype.nd_buffer.from_ndarray_like(out.reshape(chunk_spec.shape))
 
     async def _encode_single(self, chunk_ndbuffer: NDBuffer, chunk_spec: ArraySpec) -> Buffer:
         chunk_ndarray = chunk_ndbuffer.as_ndarray_like()
-        out = await to_thread(self._codec.encode, chunk_ndarray)
+        out = await asyncio.to_thread(self._codec.encode, chunk_ndarray)
         return chunk_spec.prototype.buffer.from_bytes(out)
 
 


### PR DESCRIPTION
This syncs the zarr3 wrapper with the latest zarr beta. 

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
