### PR TITLE
Unused import

### DIFF
--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402,F401
+# ruff: noqa: E402
 """Numcodecs is a Python package providing buffer compression and
 transformation codecs for use in data storage and communication
 applications. These include:
@@ -21,8 +21,9 @@ import atexit
 import multiprocessing
 from contextlib import suppress
 
-from numcodecs.registry import get_codec, register_codec
-from numcodecs.version import version as __version__
+from numcodecs.registry import get_codec as get_codec
+from numcodecs.registry import register_codec
+from numcodecs.version import version as __version__  # noqa: F401
 from numcodecs.zlib import Zlib
 
 register_codec(Zlib)
@@ -55,13 +56,13 @@ with suppress(ImportError):
     atexit.register(blosc.destroy)
 
 with suppress(ImportError):
-    from numcodecs import zstd
+    from numcodecs import zstd as zstd
     from numcodecs.zstd import Zstd
 
     register_codec(Zstd)
 
 with suppress(ImportError):
-    from numcodecs import lz4
+    from numcodecs import lz4 as lz4
     from numcodecs.lz4 import LZ4
 
     register_codec(LZ4)
@@ -127,7 +128,7 @@ from numcodecs.json import JSON
 register_codec(JSON)
 
 with suppress(ImportError):
-    from numcodecs import vlen
+    from numcodecs import vlen as vlen
     from numcodecs.vlen import VLenArray, VLenBytes, VLenUTF8
 
     register_codec(VLenUTF8)

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -1,7 +1,6 @@
 # ruff: noqa: F401
 import array
 import codecs
-import functools
 
 import numpy as np
 

--- a/numcodecs/compat.py
+++ b/numcodecs/compat.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 import array
 import codecs
 


### PR DESCRIPTION
~~I'm surprised ruff rule [F401](https://docs.astral.sh/ruff/rules/unused-import/) did not catch this.~~ The relevant ruff rule [F401](https://docs.astral.sh/ruff/rules/unused-import/) is currently disabled in this file:
https://github.com/zarr-developers/numcodecs/blob/c283106bd970952e6581a270e9bbad478e908860/numcodecs/compat.py#L1

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
