### PR TITLE
Update deprecated stage names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
   autofix_prs: false
-default_stages: [commit, push]
+default_stages: [pre-commit, pre-push]
 default_language_version:
   python: python3
 repos:


### PR DESCRIPTION
Fixes this CI warning:

![default_stages](https://private-user-images.githubusercontent.com/3234522/376158408-80a4c629-2217-4df9-965d-5bbe079f5484.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mjg5MTE0MTIsIm5iZiI6MTcyODkxMTExMiwicGF0aCI6Ii8zMjM0NTIyLzM3NjE1ODQwOC04MGE0YzYyOS0yMjE3LTRkZjktOTY1ZC01YmJlMDc5ZjU0ODQucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MTAxNCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDEwMTRUMTMwNTEyWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9Nzc5YWYyZmJkYTc2YTc4NGM5MTNmOTk3OGY3NWNkNTYyYzY3YzQyMTEwZjBkYzNkZWExZTJjMjlkYjliYmEyZCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.--uHY53AwJYylmKzXHAZgLdtQLPzoLjkLjJQaRXDZqM)

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
