### PR TITLE
Enforce more ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,17 +139,25 @@ line-length = 100
 [tool.ruff.lint]
 extend-select = [
     "B",
+    "FLY",
+    "FURB",
+    "G",
     "I",
+    "PERF",
     "PGH",
     "PIE",
     "PT",
+    "PYI",
     "RSE",
     "RUF",
     "UP",
+    # "W",  https://github.com/astral-sh/ruff/issues/13763
 ]
 ignore = [
     "B028",
     "B904",
+    "FURB101",
+    "FURB103",
     "PT001",
     "PT004",  # deprecated
     "PT005",  # deprecated


### PR DESCRIPTION
Trying to be on par with zarr-python.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
