### PR TITLE
Copy in `BitRound`

### DIFF
--- a/numcodecs/bitround.py
+++ b/numcodecs/bitround.py
@@ -59,7 +59,8 @@ class BitRound(Codec):
             return a
         if self.keepbits > bits:
             raise ValueError("Keepbits too large for given dtype")
-        b = a.astype(a_int_dtype, copy=True)
+        b = a.copy()
+        b = b.view(a_int_dtype)
         maskbits = bits - self.keepbits
         mask = (all_set >> maskbits) << maskbits
         half_quantum1 = (1 << (maskbits - 1)) - 1

--- a/numcodecs/bitround.py
+++ b/numcodecs/bitround.py
@@ -59,12 +59,12 @@ class BitRound(Codec):
             return a
         if self.keepbits > bits:
             raise ValueError("Keepbits too large for given dtype")
-        b = a.view(a_int_dtype)
+        b = a.astype(a_int_dtype, copy=True)
         maskbits = bits - self.keepbits
         mask = (all_set >> maskbits) << maskbits
         half_quantum1 = (1 << (maskbits - 1)) - 1
-        b = b + ((b >> maskbits) & 1) + half_quantum1
-        b = b & mask
+        b += ((b >> maskbits) & 1) + half_quantum1
+        b &= mask
         return b
 
     def decode(self, buf, out=None):

--- a/numcodecs/bitround.py
+++ b/numcodecs/bitround.py
@@ -63,8 +63,8 @@ class BitRound(Codec):
         maskbits = bits - self.keepbits
         mask = (all_set >> maskbits) << maskbits
         half_quantum1 = (1 << (maskbits - 1)) - 1
-        b += ((b >> maskbits) & 1) + half_quantum1
-        b &= mask
+        b = b + ((b >> maskbits) & 1) + half_quantum1
+        b = b & mask
         return b
 
     def decode(self, buf, out=None):


### PR DESCRIPTION
I was benchmarking different compression options and realized `BitRound` was overwriting my array in place.

```python
import shutil
import dask.array as da
from numcodecs import BitRound

def write_to_store(array, **kwargs):
    shutil.rmtree("test.zarr", ignore_errors=True)
    array.to_zarr("test.zarr", **kwargs)
    print(array.mean().compute())

array = da.random.default_rng(42).random((1,)).persist()

write_to_store(array)
write_to_store(array, filters=[BitRound(keepbits=5)])
write_to_store(array)
```

```
0.9167441575549085
0.921875
0.921875
```

Looks like there was [discussion](https://github.com/zarr-developers/numcodecs/pull/299#discussion_r772477738) on this in the original PR but nothing came of it. Making an explicit copy seems to work fine as well, not sure which is preferred?

cc @rabernat 

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
