### PR TITLE
Release note for `BitRound` input mutation fix

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -8,6 +8,14 @@ Release notes
 
 .. _unreleased:
 
+X.Y.Z
+-----
+
+Fix
+~~~
+* Fix in-place mutation of input array in `BitRound`.
+  By :user:`Sam Levang <slevang>`, :issue:`608`
+
 0.13.1
 ------
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -8,13 +8,16 @@ Release notes
 
 .. _unreleased:
 
-X.Y.Z
------
+Unreleased
+----------
 
 Fix
 ~~~
 * Fix in-place mutation of input array in `BitRound`.
   By :user:`Sam Levang <slevang>`, :issue:`608`
+
+
+.. _release_0.13.1:
 
 0.13.1
 ------


### PR DESCRIPTION
Adds a release note for PR: https://github.com/zarr-developers/numcodecs/pull/608

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
