### PR TITLE
Error on warnings when testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
         shell: "bash -l {0}"
         run: |
           conda activate env
-          python -m pip install "zfpy>=1" "numpy<2"
+          python -m pip install -v ".[zfpy]"
 
       - name: List installed packages
         shell: "bash -l {0}"

--- a/numcodecs/tests/test_compat.py
+++ b/numcodecs/tests/test_compat.py
@@ -64,6 +64,7 @@ def test_ensure_bytes_invalid_inputs():
             ensure_bytes(e)
 
 
+@pytest.mark.filterwarnings("ignore:The 'u' type code is deprecated and will be removed in Python 3.16")
 def test_ensure_contiguous_ndarray_invalid_inputs():
     # object array not allowed
     a = np.array(['Xin chào thế giới'], dtype=object)

--- a/numcodecs/tests/test_compat.py
+++ b/numcodecs/tests/test_compat.py
@@ -64,7 +64,9 @@ def test_ensure_bytes_invalid_inputs():
             ensure_bytes(e)
 
 
-@pytest.mark.filterwarnings("ignore:The 'u' type code is deprecated and will be removed in Python 3.16")
+@pytest.mark.filterwarnings(
+    "ignore:The 'u' type code is deprecated and will be removed in Python 3.16"
+)
 def test_ensure_contiguous_ndarray_invalid_inputs():
     # object array not allowed
     a = np.array(['Xin chào thế giới'], dtype=object)

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -54,7 +54,10 @@ def test_backwards_compatibility():
     codec = MsgPack()
     check_backwards_compatibility(codec.codec_id, arrays, [codec])
 
-@pytest.mark.filterwarnings("ignore:Creating an ndarray from ragged nested sequences .* is deprecated.*")
+
+@pytest.mark.filterwarnings(
+    "ignore:Creating an ndarray from ragged nested sequences .* is deprecated.*"
+)
 @pytest.mark.parametrize(
     ("input_data", "dtype"),
     [

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -54,7 +54,7 @@ def test_backwards_compatibility():
     codec = MsgPack()
     check_backwards_compatibility(codec.codec_id, arrays, [codec])
 
-
+@pytest.mark.filterwarnings("ignore:Creating an ndarray from ragged nested sequences .* is deprecated.*")
 @pytest.mark.parametrize(
     ("input_data", "dtype"),
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,10 @@ norecursedirs = [
 ]
 log_cli_level = "INFO"
 xfail_strict = true
+filterwarnings = [
+    "error",
+]
+
 [tool.cibuildwheel]
 environment = { DISABLE_NUMCODECS_AVX2=1 }
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
Before https://github.com/zarr-developers/numcodecs/pull/619, it would be good to convert test warnings to errors, so we can make sure there aren't any warnings being raised that we're not expecting.