### PR TITLE
Remove trailing .0 from CI Python version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13.0"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         # macos-12 is an intel runner, macos-14 is a arm64 runner
         platform: [ubuntu-latest, windows-latest, macos-12, macos-14]
 
@@ -64,7 +64,7 @@ jobs:
           python -m pip install -v -e .[test,test_extras,msgpack,crc32c]
 
       - name: Install pcodec
-        if: matrix.python-version != '3.13.0'
+        if: matrix.python-version != '3.13'
         shell: "bash -l {0}"
         run: |
             conda activate env


### PR DESCRIPTION
Otherwise we'll need to keep manually updating the micro version!