### PR TITLE
Fix minimum numpy pin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,9 @@ jobs:
 
       - name: Install zarr-python
         shell: "bash -l {0}"
+        # Since zarr v3 requires numpy >= 1.25, on Python 3.11 leave it out
+        # so we can have some tests of our minimum version of numpy (1.24)
+        if: matrix.python-version != '3.11'
         run: |
           conda activate env
           # TODO: remove --pre option when zarr v3 is out

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-import numcodecs.zarr3
-
 zarr = pytest.importorskip("zarr")
+
+import numcodecs.zarr3  # noqa: E402
 
 pytestmark = [
     pytest.mark.skipif(zarr.__version__ < "3.0.0", reason="zarr 3.0.0 or later is required"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ A Python package providing buffer compression and transformation codecs \
 for use in data storage and communication applications."""
 readme =  "README.rst"
 dependencies = [
-    "numpy>=1.23",
+    "numpy>=1.24",
 ]
 requires-python = ">=3.11"
 dynamic = [


### PR DESCRIPTION
Fixes a mistake in https://github.com/zarr-developers/numcodecs/pull/622

Also fixes issues introduced by https://github.com/zarr-developers/numcodecs/pull/524. The problem was `zarr==3` has a `numpy>=1.25` pin, which doesn't adhere to SPEC 0 and our pin (currently `numpy>=1.24`), so on Python 3.11 don't install and run the zarr v3 tests.