### PR TITLE
Release notes for 0.14

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -11,14 +11,11 @@ Release notes
 Unreleased
 ----------
 
-Fix
-~~~
-* Fix in-place mutation of input array in `BitRound`.
-  By :user:`Sam Levang <slevang>`, :issue:`608`
-* Fix an issue where importing numcodecs would lock the state of `multiprocessing`
-  and prevent user code to call `multiprocessing.set_start_method("spawn")`
-  subsequently.
-  By :user:`Clément Robert <neutrinoceros>` :issue:`522`
+
+.. _release_0.14.0:
+
+0.14.0
+------
 
 Enhancements
 ~~~~~~~~~~~~
@@ -26,6 +23,15 @@ Enhancements
   By :user:`Norman Rzepka <normanrz>`, :issue:`613`.
 * Add codec wrappers for Zarr 3.
   By :user:`Norman Rzepka <normanrz>`, :issue:`524`
+
+Fixes
+~~~~~
+* Fix in-place mutation of input array in `BitRound`.
+  By :user:`Sam Levang <slevang>`, :issue:`608`
+* Fix an issue where importing numcodecs would lock the state of `multiprocessing`
+  and prevent user code to call `multiprocessing.set_start_method("spawn")`
+  subsequently.
+  By :user:`Clément Robert <neutrinoceros>` :issue:`522`
 
 Maintenance
 ~~~~~~~~~~~


### PR DESCRIPTION
Release notes for 0.14. I'd like to get https://github.com/zarr-developers/numcodecs/pull/460 in before this, and then do a release.