### PR TITLE
Exclude tests from coverage

### DIFF
--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -249,13 +249,13 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
         fixture_dir = os.path.join('fixture', codec_id, prefix)
     else:
         fixture_dir = os.path.join('fixture', codec_id)
-    if not os.path.exists(fixture_dir):  # pragma: no cover
+    if not os.path.exists(fixture_dir):
         os.makedirs(fixture_dir)
 
     # save fixture data
     for i, arr in enumerate(arrays):
         arr_fn = os.path.join(fixture_dir, f'array.{i:02d}.npy')
-        if not os.path.exists(arr_fn):  # pragma: no cover
+        if not os.path.exists(arr_fn):
             np.save(arr_fn, arr)
 
     # load fixture data
@@ -275,13 +275,13 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
 
             # setup a directory to hold encoded data
             codec_dir = os.path.join(fixture_dir, f'codec.{j:02d}')
-            if not os.path.exists(codec_dir):  # pragma: no cover
+            if not os.path.exists(codec_dir):
                 os.makedirs(codec_dir)
 
             # file with codec configuration information
             codec_fn = os.path.join(codec_dir, 'config.json')
             # one time save config
-            if not os.path.exists(codec_fn):  # pragma: no cover
+            if not os.path.exists(codec_fn):
                 with open(codec_fn, mode='w') as cf:
                     _json.dump(codec.get_config(), cf, sort_keys=True, indent=4)
             # load config and compare with expectation
@@ -292,7 +292,7 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
             enc_fn = os.path.join(codec_dir, f'encoded.{i:02d}.dat')
 
             # one time encode and save array
-            if not os.path.exists(enc_fn):  # pragma: no cover
+            if not os.path.exists(enc_fn):
                 enc = codec.encode(arr)
                 enc = ensure_bytes(enc)
                 with open(enc_fn, mode='wb') as ef:

--- a/numcodecs/tests/package_with_entrypoint/__init__.py
+++ b/numcodecs/tests/package_with_entrypoint/__init__.py
@@ -4,8 +4,8 @@ from numcodecs.abc import Codec
 class TestCodec(Codec):
     codec_id = "test"
 
-    def encode(self, buf):  # pragma: no cover
+    def encode(self, buf):
         pass
 
-    def decode(self, buf, out=None):  # pragma: no cover
+    def decode(self, buf, out=None):
         pass

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -7,7 +7,7 @@ import pytest
 try:
     from numcodecs import blosc
     from numcodecs.blosc import Blosc
-except ImportError:  # pragma: no cover
+except ImportError:
     pytest.skip("numcodecs.blosc not available", allow_module_level=True)
 
 

--- a/numcodecs/tests/test_entrypoints_backport.py
+++ b/numcodecs/tests/test_entrypoints_backport.py
@@ -8,7 +8,7 @@ import pytest
 import numcodecs.registry
 
 importlib_spec = importlib.util.find_spec("importlib_metadata")
-if importlib_spec is None or importlib_spec.loader is None:  # pragma: no cover
+if importlib_spec is None or importlib_spec.loader is None:
     pytest.skip(
         "This test module requires importlib_metadata to be installed",
         allow_module_level=True,

--- a/numcodecs/tests/test_lz4.py
+++ b/numcodecs/tests/test_lz4.py
@@ -5,7 +5,7 @@ import pytest
 
 try:
     from numcodecs.lz4 import LZ4
-except ImportError:  # pragma: no cover
+except ImportError:
     pytest.skip("numcodecs.lz4 not available", allow_module_level=True)
 
 

--- a/numcodecs/tests/test_lzma.py
+++ b/numcodecs/tests/test_lzma.py
@@ -7,7 +7,7 @@ import pytest
 try:
     # noinspection PyProtectedMember
     from numcodecs.lzma import LZMA, _lzma
-except ImportError as e:  # pragma: no cover
+except ImportError as e:
     raise unittest.SkipTest("LZMA not available") from e
 
 

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -5,7 +5,7 @@ import pytest
 
 try:
     from numcodecs.msgpacks import MsgPack
-except ImportError as e:  # pragma: no cover
+except ImportError as e:
     raise unittest.SkipTest("msgpack not available") from e
 
 

--- a/numcodecs/tests/test_pcodec.py
+++ b/numcodecs/tests/test_pcodec.py
@@ -6,7 +6,7 @@ from numcodecs.pcodec import PCodec
 try:
     # initializing codec triggers ImportError
     PCodec()
-except ImportError:  # pragma: no cover
+except ImportError:
     pytest.skip("pcodec not available", allow_module_level=True)
 
 from numcodecs.tests.common import (

--- a/numcodecs/tests/test_registry.py
+++ b/numcodecs/tests/test_registry.py
@@ -39,4 +39,4 @@ def test_all_classes_registered():
     )
 
     if missing:
-        raise Exception(f"these codecs are missing: {missing}")  # pragma: no cover
+        raise Exception(f"these codecs are missing: {missing}")

--- a/numcodecs/tests/test_shuffle.py
+++ b/numcodecs/tests/test_shuffle.py
@@ -6,7 +6,7 @@ import pytest
 
 try:
     from numcodecs.shuffle import Shuffle
-except ImportError:  # pragma: no cover
+except ImportError:
     pytest.skip("numcodecs.shuffle not available", allow_module_level=True)
 
 

--- a/numcodecs/tests/test_vlen_array.py
+++ b/numcodecs/tests/test_vlen_array.py
@@ -5,7 +5,7 @@ import pytest
 
 try:
     from numcodecs.vlen import VLenArray
-except ImportError as e:  # pragma: no cover
+except ImportError as e:
     raise unittest.SkipTest("vlen-array not available") from e
 from numcodecs.tests.common import (
     assert_array_items_equal,

--- a/numcodecs/tests/test_vlen_bytes.py
+++ b/numcodecs/tests/test_vlen_bytes.py
@@ -5,7 +5,7 @@ import pytest
 
 try:
     from numcodecs.vlen import VLenBytes
-except ImportError as e:  # pragma: no cover
+except ImportError as e:
     raise unittest.SkipTest("vlen-bytes not available") from e
 from numcodecs.tests.common import (
     assert_array_items_equal,

--- a/numcodecs/tests/test_vlen_utf8.py
+++ b/numcodecs/tests/test_vlen_utf8.py
@@ -5,7 +5,7 @@ import pytest
 
 try:
     from numcodecs.vlen import VLenUTF8
-except ImportError as e:  # pragma: no cover
+except ImportError as e:
     raise unittest.SkipTest("vlen-utf8 not available") from e
 from numcodecs.tests.common import (
     assert_array_items_equal,

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -215,7 +215,7 @@ def test_generic_bytes_codec(store: Store, codec_class: type[numcodecs.zarr3._Nu
         if "codec not available" in str(e):
             pytest.xfail(f"{codec_class.codec_name} is not available: {e}")
         else:
-            raise  # pragma: no cover
+            raise
     except ImportError as e:
         pytest.xfail(f"{codec_class.codec_name} is not available: {e}")
 

--- a/numcodecs/tests/test_zarr3_import.py
+++ b/numcodecs/tests/test_zarr3_import.py
@@ -8,6 +8,6 @@ def test_zarr3_import():
 
     try:
         import zarr  # noqa: F401
-    except ImportError:  # pragma: no cover
+    except ImportError:
         with pytest.raises(ImportError, match=ERROR_MESSAGE_MATCH):
             import numcodecs.zarr3  # noqa: F401

--- a/numcodecs/tests/test_zfpy.py
+++ b/numcodecs/tests/test_zfpy.py
@@ -4,7 +4,7 @@ import pytest
 try:
     # noinspection PyProtectedMember
     from numcodecs.zfpy import ZFPY, _zfpy
-except ImportError:  # pragma: no cover
+except ImportError:
     pytest.skip("ZFPY not available", allow_module_level=True)
 
 

--- a/numcodecs/tests/test_zstd.py
+++ b/numcodecs/tests/test_zstd.py
@@ -5,7 +5,7 @@ import pytest
 
 try:
     from numcodecs.zstd import Zstd
-except ImportError:  # pragma: no cover
+except ImportError:
     pytest.skip("numcodecs.zstd not available", allow_module_level=True)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,11 @@ write_to = "numcodecs/version.py"
 skip = "./.git,fixture"
 ignore-words-list = "ba, compiletime, hist, nd, unparseable"
 
+[tool.coverage.run]
+omit = [
+    "numcodecs/tests/**",
+]
+
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
Tests files shouldn't be examined for coverage, should they?

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
