### PR TITLE
Make contributing doc page title shorter

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,5 +1,5 @@
-Contributing to NumCodecs
-=========================
+Contributing
+============
 
 NumCodecs is a community maintained project. We welcome contributions in the form of bug
 reports, bug fixes, documentation, enhancement proposals and more. This page provides


### PR DESCRIPTION
Should make it look nicer in the doc header - currently it's a bit cramped:

![Screenshot 2024-11-13 at 12 35 05](https://github.com/user-attachments/assets/9d02ae3e-9e6b-4871-907e-fd03ab9a3b2b)
