### PR TITLE
Cleanup `crc32c` soft dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,4 @@ repos:
       hooks:
       -   id: mypy
           args: [--config-file, pyproject.toml]
-          additional_dependencies: [numpy, pytest, zfpy, 'zarr==3.0.0b1']
+          additional_dependencies: [numpy, pytest, crc32c, zfpy, 'zarr==3.0.0b1']

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -11,6 +11,11 @@ Release notes
 Unreleased
 ----------
 
+Fixes
+~~~~~
+* Cleanup ``crc32c`` soft dependency.
+  By :user:`John Kirkham <jakirkham>`, :issue:`637`
+
 
 .. _release_0.14.0:
 

--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -117,12 +117,16 @@ with suppress(ImportError):
 
     register_codec(MsgPack)
 
-from numcodecs.checksum32 import CRC32, CRC32C, Adler32, JenkinsLookup3
+from numcodecs.checksum32 import CRC32, Adler32, JenkinsLookup3
 
 register_codec(CRC32)
-register_codec(CRC32C)
 register_codec(Adler32)
 register_codec(JenkinsLookup3)
+
+with suppress(ImportError):
+    from numcodecs.checksum32 import CRC32C
+
+    register_codec(CRC32C)
 
 from numcodecs.json import JSON
 

--- a/numcodecs/tests/test_checksum32.py
+++ b/numcodecs/tests/test_checksum32.py
@@ -1,13 +1,10 @@
 import itertools
+from contextlib import suppress
 
 import numpy as np
 import pytest
 
-try:
-    from numcodecs.checksum32 import CRC32, CRC32C, Adler32
-except ImportError:  # pragma: no cover
-    pytest.skip("numcodecs.checksum32 not available", allow_module_level=True)
-
+from numcodecs.checksum32 import CRC32, Adler32
 from numcodecs.tests.common import (
     check_backwards_compatibility,
     check_config,
@@ -16,6 +13,12 @@ from numcodecs.tests.common import (
     check_err_encode_object_buffer,
     check_repr,
 )
+
+has_crc32c = False
+with suppress(ImportError):
+    from numcodecs.checksum32 import CRC32C
+
+    has_crc32c = True
 
 # mix of dtypes: integer, float, bool, string
 # mix of shapes: 1D, 2D, 3D
@@ -39,11 +42,16 @@ arrays = [
 codecs = [
     CRC32(),
     CRC32(location="end"),
-    CRC32C(location="start"),
-    CRC32C(),
     Adler32(),
     Adler32(location="end"),
 ]
+if has_crc32c:
+    codecs.extend(
+        [
+            CRC32C(location="start"),
+            CRC32C(),
+        ]
+    )
 
 
 @pytest.mark.parametrize(("codec", "arr"), itertools.product(codecs, arrays))
@@ -89,24 +97,27 @@ def test_err_location():
     with pytest.raises(ValueError):
         CRC32(location="foo")
     with pytest.raises(ValueError):
-        CRC32C(location="foo")
-    with pytest.raises(ValueError):
         Adler32(location="foo")
+    if has_crc32c:
+        with pytest.raises(ValueError):
+            CRC32C(location="foo")
 
 
 def test_repr():
     check_repr("CRC32(location='start')")
-    check_repr("CRC32C(location='start')")
-    check_repr("Adler32(location='start')")
     check_repr("CRC32(location='end')")
-    check_repr("CRC32C(location='end')")
+    check_repr("Adler32(location='start')")
     check_repr("Adler32(location='end')")
+    if has_crc32c:
+        check_repr("CRC32C(location='start')")
+        check_repr("CRC32C(location='end')")
 
 
 def test_backwards_compatibility():
     check_backwards_compatibility(CRC32.codec_id, arrays, [CRC32()])
     check_backwards_compatibility(Adler32.codec_id, arrays, [Adler32()])
-    check_backwards_compatibility(CRC32C.codec_id, arrays, [CRC32C()])
+    if has_crc32c:
+        check_backwards_compatibility(CRC32C.codec_id, arrays, [CRC32C()])
 
 
 @pytest.mark.parametrize("codec", codecs)
@@ -127,6 +138,7 @@ def test_err_out_too_small(codec):
         codec.decode(codec.encode(arr), out)
 
 
+@pytest.mark.skipif(not has_crc32c, reason="Needs `crc32c` installed")
 def test_crc32c_checksum():
     arr = np.arange(0, 64, dtype="uint8")
     buf = CRC32C(location="end").encode(arr)


### PR DESCRIPTION
Instead of creating a wrapper function around the call to `crc32c`'s to check if it can be `import`ed. Try `import`ing `crc32c` when `numcodecs.checksum32` is `import`ed. If it cannot be `import`ed, don't define the `CRC32C` class and skip registering it at the top-level with other `Codec`s.

This matches the behavior that Numcodecs has with all other optional codecs and cuts out unneeded overhead when using this checksum routine.

xref: https://github.com/zarr-developers/numcodecs/pull/613

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
