### PR TITLE
Fail CI if codecov doesn't upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,5 +102,6 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
On https://github.com/zarr-developers/numcodecs/pull/637 and other PRs, it looks like the code coverage is failing because some reports fail to upload, but this isn't failing the CI jobs so it's not obvious.

This PR changes that so CI fails if coverage does not succesfully upload to codecov.