### PR TITLE
Add `noexcept` to `_utils` C-equiv functions

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -11,6 +11,12 @@ Release notes
 Unreleased
 ----------
 
+Fix
+~~~
+
+* Add `noexcept` to `_utils` C-equiv functions
+  By :user:`John Kirkham <jakirkham>`, :issue:`641`.
+
 
 .. _release_0.14.0:
 

--- a/numcodecs/_utils.pxd
+++ b/numcodecs/_utils.pxd
@@ -8,14 +8,14 @@
 from libc.stdint cimport uint8_t, uint32_t
 
 
-cdef inline void store_le32(uint8_t c[4], uint32_t i) nogil:
+cdef inline void store_le32(uint8_t c[4], uint32_t i) nogil noexcept:
     c[0] = i & 0xFF
     c[1] = (i >> 8) & 0xFF
     c[2] = (i >> 16) & 0xFF
     c[3] = (i >> 24) & 0xFF
 
 
-cdef inline uint32_t load_le32(const uint8_t c[4]) nogil:
+cdef inline uint32_t load_le32(const uint8_t c[4]) nogil noexcept:
     return (
         c[0] |
         (c[1] << 8) |


### PR DESCRIPTION
The functions in `_utils` are effectively straight C functions. In Cython 0.x, these would have been treated as `noexcept` by default. However in Cython 3.x all functions are treated as potentially raising exceptions (including these). While that is a sensible default in general, these functions still won't raise exceptions. So tidy things up by adding `noexcept` to turn off the additional Cython checks emitted in and around them.

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
