### PR TITLE
Drop unnecessary dependency on mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ docs = [
     "sphinx-issues",
     "pydata-sphinx-theme",
     "numpydoc",
-    "mock",
 ]
 test = [
     "coverage",


### PR DESCRIPTION
Mock is only used in docs/conf.py but the `unittest.mock` from the standard library is used so an external mock dependency is not needed.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [X] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [X] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
