### PR TITLE
Type `Buffer`'s `flags` argument

### DIFF
--- a/numcodecs/compat_ext.pyx
+++ b/numcodecs/compat_ext.pyx
@@ -12,7 +12,7 @@ from .compat import ensure_contiguous_ndarray
 cdef class Buffer:
     """Convenience class for buffer interface."""
 
-    def __cinit__(self, obj, flags):
+    def __cinit__(self, obj, int flags):
         PyObject_GetBuffer(obj, &(self.buffer), flags)
         self.acquired = True
         self.ptr = <char *> self.buffer.buf


### PR DESCRIPTION
Ensure the `flags` argument in `Buffer` is correctly typed so it can be passed verbatim to `PyObject_GetBuffer`. This can also avoid needless conversions to and from Python `object` type.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
