### PR TITLE
Remove unused pytest skip

### DIFF
--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -50,9 +50,7 @@ def test_entry_points(codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
 
 @pytest.mark.parametrize("codec_class", ALL_CODECS)
 def test_docstring(codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
-    if codec_class.__doc__ is None:
-        pytest.skip()
-    assert "See :class:`numcodecs." in codec_class.__doc__
+    assert "See :class:`numcodecs." in codec_class.__doc__  # type: ignore[operator]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I originally included the `pytest.skip` because in rare cases (I think debug builds of Cpython??) docstrings can return `None` instead of their contents. I think this is rare enough that we don't need to care about it, and it's better just adding a `# type: ignore` comment instead of a `pytest.skip`.

I'm hoping this gets code coverage back up to 100% again to fix https://github.com/zarr-developers/numcodecs/issues/646