### PR TITLE
Imported name is not used anywhere in the module

### DIFF
--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -8,7 +8,7 @@ from numcodecs.abc import Codec
 
 logger = logging.getLogger("numcodecs")
 codec_registry: dict[str, Codec] = {}
-entries: dict[str, "EntryPoints"] = {}
+entries: dict[str, EntryPoints] = {}
 
 
 def run_entrypoints():


### PR DESCRIPTION
TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
