### PR TITLE
Adds `astype` config for Delta in Zarr 3 wrapper

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -25,6 +25,8 @@ Fixes
   ``crc32c`` is not installed. This has been changed to match
   the behaviour of other optional dependencies/codecs.
   By :user:`John Kirkham <jakirkham>`, :issue:`637`
+* Fixes issue with ``Delta`` Zarr 3 codec not working with ``astype``.
+  By :user:`Norman Rzepka <normanrz>`, :issue:`664`
 
 Improvements
 ~~~~~~~~~~~~

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -13,6 +13,19 @@ Release notes
 
 .. _unreleased:
 
+Unreleased
+----------
+
+Fixes
+~~~~~
+* Fixes issue with ``Delta`` Zarr 3 codec not working with ``astype``.
+  By :user:`Norman Rzepka <normanrz>`, :issue:`664`
+
+
+Improvements
+~~~~~~~~~~~~
+
+
 0.14.1
 ------
 
@@ -25,8 +38,6 @@ Fixes
   ``crc32c`` is not installed. This has been changed to match
   the behaviour of other optional dependencies/codecs.
   By :user:`John Kirkham <jakirkham>`, :issue:`637`
-* Fixes issue with ``Delta`` Zarr 3 codec not working with ``astype``.
-  By :user:`Norman Rzepka <normanrz>`, :issue:`664`
 
 Improvements
 ~~~~~~~~~~~~

--- a/docs/zarr3.rst
+++ b/docs/zarr3.rst
@@ -1,3 +1,5 @@
+.. _Zarr 3 codecs:
+
 Zarr 3 codecs
 =============
 .. automodule:: numcodecs.zarr3

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -266,7 +266,19 @@ class Shuffle(_NumcodecsBytesBytesCodec):
 
 
 # array-to-array codecs ("filters")
-Delta = _add_docstring(_make_array_array_codec("delta", "Delta"), "numcodecs.delta.Delta")
+@_add_docstring_wrapper("numcodecs.delta.Delta")
+class Delta(_NumcodecsArrayArrayCodec):
+    codec_name = f"{CODEC_PREFIX}delta"
+
+    def __init__(self, **codec_config: dict[str, JSON]) -> None:
+        super().__init__(**codec_config)
+
+    def resolve_metadata(self, chunk_spec: ArraySpec) -> ArraySpec:
+        if astype := self.codec_config.get("astype"):
+            return replace(chunk_spec, dtype=np.dtype(astype))  # type: ignore[arg-type]
+        return chunk_spec
+
+
 BitRound = _add_docstring(
     _make_array_array_codec("bitround", "BitRound"), "numcodecs.bitround.BitRound"
 )


### PR DESCRIPTION
Adds `astype` config for Delta in Zarr 3 wrapper.
Fixes #663 

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
