### PR TITLE
Simplify conda use in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,10 +38,9 @@ jobs:
 
       - name: Install clang
         if: matrix.platform == 'macos-13'
-        run: |
-          conda install -y 'clang>=12.0.1,<17'
+        run: conda install -y 'clang>=12.0.1,<17'
 
-      - name: Show info about conda environment
+      - name: Show conda environment info
         run: |
           conda info
           conda config --show-sources
@@ -55,16 +54,14 @@ jobs:
 
       - name: Install pcodec
         if: matrix.python-version != '3.13'
-        run: |
-          python -m pip install -v ".[pcodec]"
+        run: python -m pip install -v ".[pcodec]"
 
       - name: Install zarr-python
         # Since zarr v3 requires numpy >= 1.25, on Python 3.11 leave it out
         # so we can have some tests of our minimum version of numpy (1.24)
         if: matrix.python-version != '3.11'
-        run: |
-          # TODO: remove --pre option when zarr v3 is out
-          python -m pip install --pre zarr>=3.0.0b2
+        # TODO: remove --pre option when zarr v3 is out
+        run: python -m pip install --pre zarr>=3.0.0b2
 
       # This is used to test with zfpy, which does not yet support numpy 2.0
       - name: Install older numpy and zfpy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,11 +50,7 @@ jobs:
         run: |
           export DISABLE_NUMCODECS_AVX2=""
           # TODO: put back zfpy import when it supports numpy 2.0
-          python -m pip install -v -e .[test,test_extras,msgpack,crc32c]
-
-      - name: Install pcodec
-        if: matrix.python-version != '3.13'
-        run: python -m pip install -v ".[pcodec]"
+          python -m pip install -v -e .[test,test_extras,msgpack,crc32c,pcodec]
 
       - name: Install zarr-python
         # Since zarr v3 requires numpy >= 1.25, on Python 3.11 leave it out

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,10 @@ jobs:
         # macos-13 is an intel runner, macos-14 is a arm64 runner
         platform: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
+    defaults:
+      run:
+        shell: bash -el {0}
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -25,80 +29,54 @@ jobs:
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3.1.0
         with:
-            channels: conda-forge
-            miniforge-version: latest
-            python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          miniforge-version: latest
+          python-version: ${{ matrix.python-version }}
 
-      - name: Show info about `base` environment
-        shell: "bash -l {0}"
+      - name: Install compilers
+        run: conda install -y c-compiler cxx-compiler
+
+      - name: Install clang
+        if: matrix.platform == 'macos-13'
+        run: |
+          conda install -y 'clang>=12.0.1,<17'
+
+      - name: Show info about conda environment
         run: |
           conda info
           conda config --show-sources
           conda list --show-channel-urls
 
-      - name: Set up `env`
-        shell: "bash -l {0}"
-        run: >
-          conda create -n env
-          c-compiler cxx-compiler
-          python=${{matrix.python-version}} wheel pip
-
-      - name: Install clang
-        shell: "bash -l {0}"
-        if: matrix.platform == 'macos-13'
-        run: |
-          conda activate env
-          conda install -y 'clang>=12.0.1,<17'
-
-      - name: Show info about `env` environment
-        shell: "bash -l {0}"
-        run: |
-          conda list --show-channel-urls -n env
-
       - name: Install numcodecs
-        shell: "bash -l {0}"
         run: |
-          conda activate env
           export DISABLE_NUMCODECS_AVX2=""
           # TODO: put back zfpy import when it supports numpy 2.0
           python -m pip install -v -e .[test,test_extras,msgpack,crc32c]
 
       - name: Install pcodec
         if: matrix.python-version != '3.13'
-        shell: "bash -l {0}"
         run: |
-            conda activate env
-            python -m pip install -v ".[pcodec]"
+          python -m pip install -v ".[pcodec]"
 
       - name: Install zarr-python
-        shell: "bash -l {0}"
         # Since zarr v3 requires numpy >= 1.25, on Python 3.11 leave it out
         # so we can have some tests of our minimum version of numpy (1.24)
         if: matrix.python-version != '3.11'
         run: |
-          conda activate env
           # TODO: remove --pre option when zarr v3 is out
           python -m pip install --pre zarr>=3.0.0b2
 
       # This is used to test with zfpy, which does not yet support numpy 2.0
       - name: Install older numpy and zfpy
         if: matrix.python-version == '3.11'
-        shell: "bash -l {0}"
-        run: |
-          conda activate env
-          python -m pip install -v ".[zfpy]"
+        run: python -m pip install -v ".[zfpy]"
 
       - name: List installed packages
-        shell: "bash -l {0}"
-        run: |
-          conda activate env
-          python -m pip list
+        run: python -m pip list
 
       - name: Run tests
         shell: "bash -l {0}"
-        run: |
-          conda activate env
-          pytest -v
+        run: pytest -v
 
       - uses: codecov/codecov-action@v5
         with:

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -225,7 +225,7 @@ def test_generic_bytes_codec(store: StorePath, codec_class: type[numcodecs.zarr3
             pytest.xfail(f"{codec_class.codec_name} is not available: {e}")
         else:
             raise  # pragma: no cover
-    except ImportError as e:
+    except ImportError as e:  # pragma: no cover
         pytest.xfail(f"{codec_class.codec_name} is not available: {e}")
 
     data = np.arange(0, 256, dtype="float32").reshape((16, 16))


### PR DESCRIPTION
This:

- Sets the defuault shell to avoid specifying it at every step
- Doesn't create a new environment, but uses the default one provided by `setup-miniconda`
- Puts back the install for pcodec on all Python versions, since wheels are out now

This simplifies the setup a fair bit, and cuts the total testing time by ~50% (9mins total vs 18 mins total for another recent build).