### PR TITLE
Update numcodecs tests and docs for zarr-python 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0 # required for version resolution
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
       hooks:
       -   id: mypy
           args: [--config-file, pyproject.toml]
-          additional_dependencies: [numpy, pytest, crc32c, zfpy, 'zarr>=3.0.0b2']
+          additional_dependencies: [numpy, pytest, crc32c, zfpy, 'zarr>=3.0.0rc1']

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -27,6 +27,8 @@ Fixes
 ~~~~~
 * Fixes issue with ``Delta`` Zarr 3 codec not working with ``astype``.
   By :user:`Norman Rzepka <normanrz>`, :issue:`664`
+* Fixes issues with the upcoming ``zarr`` 3.0.0 release.
+  By :user:`Norman Rzepka <normanrz>`, :issue:`675`
 
 
 Improvements

--- a/docs/zarr3.rst
+++ b/docs/zarr3.rst
@@ -5,8 +5,8 @@ Zarr 3 codecs
 .. automodule:: numcodecs.zarr3
 
 
-Bytes-to-bytes codecs
----------------------
+Compressors (bytes-to-bytes codecs)
+-----------------------------------
 .. autoclass:: Blosc()
 
     .. autoattribute:: codec_name
@@ -40,8 +40,33 @@ Bytes-to-bytes codecs
     .. autoattribute:: codec_name
 
 
-Array-to-array codecs
----------------------
+Checksum codecs (bytes-to-bytes codecs)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Need to be used as ``compressors`` in zarr-python.
+
+.. autoclass:: CRC32()
+
+    .. autoattribute:: codec_name
+
+.. autoclass:: CRC32C()
+
+    .. autoattribute:: codec_name
+
+.. autoclass:: Adler32()
+
+    .. autoattribute:: codec_name
+
+.. autoclass:: Fletcher32()
+
+    .. autoattribute:: codec_name
+
+.. autoclass:: JenkinsLookup3()
+
+    .. autoattribute:: codec_name
+
+
+Filters (array-to-array codecs)
+-------------------------------
 .. autoclass:: Delta()
 
     .. autoattribute:: codec_name
@@ -67,31 +92,9 @@ Array-to-array codecs
     .. autoattribute:: codec_name
 
 
-Bytes-to-bytes checksum codecs
-------------------------------
-.. autoclass:: CRC32()
 
-    .. autoattribute:: codec_name
-
-.. autoclass:: CRC32C()
-
-    .. autoattribute:: codec_name
-
-.. autoclass:: Adler32()
-
-    .. autoattribute:: codec_name
-
-.. autoclass:: Fletcher32()
-
-    .. autoattribute:: codec_name
-
-.. autoclass:: JenkinsLookup3()
-
-    .. autoattribute:: codec_name
-
-
-Array-to-bytes codecs
----------------------
+Serializers (array-to-bytes codecs)
+-----------------------------------
 .. autoclass:: PCodec()
 
     .. autoattribute:: codec_name

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -267,3 +267,8 @@ def test_delta_astype(store: StorePath):
         a[:, :] = data.copy()
         a = zarr.open_array(store / "generic", mode="r")
     np.testing.assert_array_equal(data, a[:, :])
+
+
+def test_repr():
+    codec = numcodecs.zarr3.LZ4(level=5)
+    assert repr(codec) == "LZ4(codec_name='numcodecs.lz4', codec_config={'level': 5})"

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -66,17 +66,19 @@ def test_docstring(codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
         numcodecs.zarr3.Shuffle,
     ],
 )
-def test_generic_codec_class(store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
+def test_generic_compressor(
+    store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsBytesBytesCodec]
+):
     data = np.arange(0, 256, dtype="uint16").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
-        a = Array.create(
+        a = zarr.create_array(
             store / "generic",
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=data.dtype,
             fill_value=0,
-            codecs=[BytesCodec(), codec_class()],
+            compressors=[codec_class()],
         )
 
     a[:, :] = data.copy()
@@ -100,26 +102,25 @@ def test_generic_codec_class(store: StorePath, codec_class: type[numcodecs.zarr3
 )
 def test_generic_filter(
     store: StorePath,
-    codec_class: type[numcodecs.zarr3._NumcodecsCodec],
+    codec_class: type[numcodecs.zarr3._NumcodecsArrayArrayCodec],
     codec_config: dict[str, JSON],
 ):
     data = np.linspace(0, 10, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
-        a = Array.create(
+        a = zarr.create_array(
             store / "generic",
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=data.dtype,
             fill_value=0,
-            codecs=[
+            filters=[
                 codec_class(**codec_config),
-                BytesCodec(),
             ],
         )
 
         a[:, :] = data.copy()
-        a = Array.open(store / "generic")
+        a = zarr.open_array(store / "generic", mode="r")
     np.testing.assert_array_equal(data, a[:, :])
 
 
@@ -127,17 +128,17 @@ def test_generic_filter_bitround(store: StorePath):
     data = np.linspace(0, 1, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
-        a = Array.create(
+        a = zarr.create_array(
             store / "generic_bitround",
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=data.dtype,
             fill_value=0,
-            codecs=[numcodecs.zarr3.BitRound(keepbits=3), BytesCodec()],
+            filters=[numcodecs.zarr3.BitRound(keepbits=3)],
         )
 
         a[:, :] = data.copy()
-        a = Array.open(store / "generic_bitround")
+        a = zarr.open_array(store / "generic_bitround", mode="r")
     assert np.allclose(data, a[:, :], atol=0.1)
 
 
@@ -145,17 +146,17 @@ def test_generic_filter_quantize(store: StorePath):
     data = np.linspace(0, 10, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
-        a = Array.create(
+        a = zarr.create_array(
             store / "generic_quantize",
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=data.dtype,
             fill_value=0,
-            codecs=[numcodecs.zarr3.Quantize(digits=3), BytesCodec()],
+            filters=[numcodecs.zarr3.Quantize(digits=3)],
         )
 
         a[:, :] = data.copy()
-        a = Array.open(store / "generic_quantize")
+        a = zarr.open_array(store / "generic_quantize", mode="r")
     assert np.allclose(data, a[:, :], atol=0.001)
 
 
@@ -164,27 +165,27 @@ def test_generic_filter_packbits(store: StorePath):
     data[0:4, :] = True
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
-        a = Array.create(
+        a = zarr.create_array(
             store / "generic_packbits",
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=data.dtype,
             fill_value=0,
-            codecs=[numcodecs.zarr3.PackBits(), BytesCodec()],
+            filters=[numcodecs.zarr3.PackBits()],
         )
 
         a[:, :] = data.copy()
-        a = Array.open(store / "generic_packbits")
+        a = zarr.open_array(store / "generic_packbits", mode="r")
     np.testing.assert_array_equal(data, a[:, :])
 
     with pytest.raises(ValueError, match=".*requires bool dtype.*"):
-        Array.create(
+        zarr.create_array(
             store / "generic_packbits_err",
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype="uint32",
             fill_value=0,
-            codecs=[numcodecs.zarr3.PackBits(), BytesCodec()],
+            filters=[numcodecs.zarr3.PackBits()],
         )
 
 
@@ -198,26 +199,30 @@ def test_generic_filter_packbits(store: StorePath):
         numcodecs.zarr3.JenkinsLookup3,
     ],
 )
-def test_generic_checksum(store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
+def test_generic_checksum(
+    store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsBytesBytesCodec]
+):
     data = np.linspace(0, 10, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
-        a = Array.create(
+        a = zarr.create_array(
             store / "generic_checksum",
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=data.dtype,
             fill_value=0,
-            codecs=[BytesCodec(), codec_class()],
+            compressors=[codec_class()],
         )
 
         a[:, :] = data.copy()
-        a = Array.open(store / "generic_checksum")
+        a = zarr.open_array(store / "generic_checksum", mode="r")
     np.testing.assert_array_equal(data, a[:, :])
 
 
 @pytest.mark.parametrize("codec_class", [numcodecs.zarr3.PCodec, numcodecs.zarr3.ZFPY])
-def test_generic_bytes_codec(store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
+def test_generic_bytes_codec(
+    store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsArrayBytesCodec]
+):
     try:
         codec_class()._codec  # noqa: B018
     except ValueError as e:
@@ -231,15 +236,13 @@ def test_generic_bytes_codec(store: StorePath, codec_class: type[numcodecs.zarr3
     data = np.arange(0, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
-        a = Array.create(
+        a = zarr.create_array(
             store / "generic",
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=data.dtype,
             fill_value=0,
-            codecs=[
-                codec_class(),
-            ],
+            serializer=codec_class(),
         )
 
     a[:, :] = data.copy()
@@ -250,18 +253,17 @@ def test_delta_astype(store: StorePath):
     data = np.linspace(0, 10, 256, dtype="i8").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
-        a = Array.create(
+        a = zarr.create_array(
             store / "generic",
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=data.dtype,
             fill_value=0,
-            codecs=[
+            filters=[
                 numcodecs.zarr3.Delta(dtype="i8", astype="i2"),  # type: ignore[arg-type]
-                BytesCodec(),
             ],
         )
 
         a[:, :] = data.copy()
-        a = Array.open(store / "generic")
+        a = zarr.open_array(store / "generic", mode="r")
     np.testing.assert_array_equal(data, a[:, :])

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -122,7 +122,9 @@ class _NumcodecsCodec(Metadata):
 
     # Override __repr__ because dynamically constructed classes don't seem to work otherwise
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(codec_name={self.codec_name!r}, codec_config={self.codec_config!r})"
+        codec_config = self.codec_config.copy()
+        codec_config.pop("id", None)
+        return f"{self.__class__.__name__}(codec_name={self.codec_name!r}, codec_config={codec_config!r})"
 
 
 class _NumcodecsBytesBytesCodec(_NumcodecsCodec, BytesBytesCodec):

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -8,12 +8,13 @@ You can use codecs from :py:mod:`numcodecs` by constructing codecs from :py:mod:
 >>> import zarr
 >>> import numcodecs.zarr3
 >>>
->>> codecs = [zarr.codecs.BytesCodec(), numcodecs.zarr3.BZ2(level=5)]
->>> array = zarr.open(
-...   "data.zarr", mode="w",
-...   shape=(1024, 1024), chunks=(64, 64),
+>>> array = zarr.create_array(
+...   store="data.zarr",
+...   shape=(1024, 1024),
+...   chunks=(64, 64),
 ...   dtype="uint32",
-...   codecs=codecs)
+...   filters=[numcodecs.zarr3.Delta()],
+...   compressors=[numcodecs.zarr3.BZ2(level=5)])
 >>> array[:] = np.arange(*array.shape).astype(array.dtype)
 
 .. note::
@@ -118,6 +119,10 @@ class _NumcodecsCodec(Metadata):
 
     def compute_encoded_size(self, input_byte_length: int, chunk_spec: ArraySpec) -> int:
         raise NotImplementedError  # pragma: no cover
+
+    # Override __repr__ because dynamically constructed classes don't seem to work otherwise
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(codec_name={self.codec_name!r}, codec_config={self.codec_config!r})"
 
 
 class _NumcodecsBytesBytesCodec(_NumcodecsCodec, BytesBytesCodec):


### PR DESCRIPTION
- Updates docs with new terms (e.g. compressors, filters, serializer)
- Overrides `_Numcodecs.__repr__` because I was getting bulky names in zarr-python tests (e.g. `_make_array_array_codec.<locals>._Codec(codec_name='numcodecs.delta', codec_config={'id': 'delta'})`) although the code is setting `__name__`. Advice appreciated.
- Change tests to use `zarr.create_array` and `zarr.open_array`

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
