### PR TITLE
Revert change to delta filter

### DIFF
--- a/numcodecs/delta.py
+++ b/numcodecs/delta.py
@@ -63,12 +63,7 @@ class Delta(Codec):
         enc[0] = arr[0]
 
         # compute differences
-        # using np.subtract for in-place operations
-        if arr.dtype == bool:
-            np.not_equal(arr[1:], arr[:-1], out=enc[1:])
-        else:
-            np.subtract(arr[1:], arr[:-1], out=enc[1:])
-
+        enc[1:] = np.diff(arr)
         return enc
 
     def decode(self, buf, out=None):


### PR DESCRIPTION
This reverts https://github.com/zarr-developers/numcodecs/pull/584, as it has caused two issues so far, one of which is unresolved: https://github.com/zarr-developers/numcodecs/issues/653 and https://github.com/zarr-developers/numcodecs/pull/595.

There is a proposed fix at https://github.com/zarr-developers/numcodecs/pull/657, but that is held up under review.

In order to un-break zarr-python, I think reverting here is the right thing to do (so we can do a 0.15 release with other stuff).

My intention is to add a test to https://github.com/zarr-developers/numcodecs/issues/653 to this PR too, so keeping as draft. Opening so there's time for folks to see that I'm intending to do this; cc @jakirkham @ehgus 