### PR TITLE
Test on zfpy again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,7 @@ jobs:
       - name: Install numcodecs
         run: |
           export DISABLE_NUMCODECS_AVX2=""
-          # TODO: put back zfpy import when it supports numpy 2.0
-          python -m pip install -v -e .[test,test_extras,msgpack,crc32c,pcodec]
+          python -m pip install -v -e .[test,test_extras,msgpack,crc32c,pcodec,zfpy]
 
       - name: Install zarr-python
         # Since zarr v3 requires numpy >= 1.25, on Python 3.11 leave it out
@@ -59,11 +58,6 @@ jobs:
         if: matrix.python-version != '3.11'
         # TODO: remove --pre option when zarr v3 is out
         run: python -m pip install --pre zarr>=3.0.0b2
-
-      # This is used to test with zfpy, which does not yet support numpy 2.0
-      - name: Install older numpy and zfpy
-        if: matrix.python-version == '3.11'
-        run: python -m pip install -v ".[zfpy]"
 
       - name: List installed packages
         run: python -m pip list


### PR DESCRIPTION
This should have gone with https://github.com/zarr-developers/numcodecs/pull/671, but I forgot. This enables testing with zfpy on all the tests, now zfpy supports numpy 2.0.