### PR TITLE
Zstd: Don't persist the checksum param if false

### DIFF
--- a/numcodecs/tests/test_zstd.py
+++ b/numcodecs/tests/test_zstd.py
@@ -90,3 +90,10 @@ def test_native_functions():
     assert Zstd.default_level() == 3
     assert Zstd.min_level() == -131072
     assert Zstd.max_level() == 22
+
+
+def test_zstd_config():
+    # Testing that checksum is removed from config if False
+    codec = Zstd(level=5, checksum=False)
+    config = codec.get_config()
+    assert config == {"id": "zstd", "level": 5}

--- a/numcodecs/zstd.pyx
+++ b/numcodecs/zstd.pyx
@@ -258,6 +258,13 @@ class Zstd(Codec):
              self.level)
         return r
 
+    # Override to remove "checksum" if False
+    def get_config(self):
+        config = {'id': self.codec_id, 'level': self.level}
+        if self.checksum:
+            config['checksum'] = True
+        return config
+
     @classmethod
     def default_level(cls):
         """Returns the default compression level of the underlying zstd library."""


### PR DESCRIPTION
Changes the zstd codec to not persist the `checksum` param, if it is set to `False` (the default). This is aimed at improving backwards compatibility.

See https://github.com/zarr-developers/zarr-python/issues/2647#issuecomment-2571758778


- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Changes documented in docs/release.rst
- [x] Docs build locally
- [ ] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
