### PR TITLE
Remove id from zarr3 config serialization

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -48,6 +48,8 @@ Fixes
   and a warning if the version was incompatible with `zfpy`.
   This check has been removed because `zfpy` now supports the newer versions of `NumPy`.
   By :user:`Meher Gajula <me-her>`, :issue:`672`
+* Remove redundant ``id`` from codec metadata serialization in Zarr3 codecs.
+  By :user:`Norman Rzepka <normanrz>`, :issue:`685`
 
 Improvements
 ~~~~~~~~~~~~

--- a/numcodecs/json.py
+++ b/numcodecs/json.py
@@ -68,7 +68,7 @@ class JSON(Codec):
     def encode(self, buf):
         try:
             buf = np.asarray(buf)
-        except ValueError:
+        except ValueError:  # pragma: no cover
             buf = np.asarray(buf, dtype=object)
         items = np.atleast_1d(buf).tolist()
         items.append(buf.dtype.str)

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -225,11 +225,11 @@ def test_generic_bytes_codec(
 ):
     try:
         codec_class()._codec  # noqa: B018
-    except ValueError as e:
+    except ValueError as e:  # pragma: no cover
         if "codec not available" in str(e):
             pytest.xfail(f"{codec_class.codec_name} is not available: {e}")
         else:
-            raise  # pragma: no cover
+            raise
     except ImportError as e:  # pragma: no cover
         pytest.xfail(f"{codec_class.codec_name} is not available: {e}")
 

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -272,3 +272,8 @@ def test_delta_astype(store: StorePath):
 def test_repr():
     codec = numcodecs.zarr3.LZ4(level=5)
     assert repr(codec) == "LZ4(codec_name='numcodecs.lz4', codec_config={'level': 5})"
+
+
+def test_to_dict():
+    codec = numcodecs.zarr3.LZ4(level=5)
+    assert codec.to_dict() == {"name": "numcodecs.lz4", "configuration": {"level": 5}}

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -112,6 +112,7 @@ class _NumcodecsCodec(Metadata):
 
     def to_dict(self) -> dict[str, JSON]:
         codec_config = self.codec_config.copy()
+        codec_config.pop("id", None)
         return {
             "name": self.codec_name,
             "configuration": codec_config,


### PR DESCRIPTION
Removes the "id" attribute from the serialization when used as zarr3 codec, because it is redundant.
Before
```json
{"name": "numcodecs.zfpy", "configuration": {"id": "zfpy", "mode": 3, "precision": 20}}
```
After:
```json
{"name": "numcodecs.zfpy", "configuration": {"mode": 3, "precision": 20}}
```

See https://ossci.zulipchat.com/#narrow/channel/423692-Zarr/topic/using.20numcodecs.20codecs.20with.20zarr_format.3D3/near/492599440

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
