### PR TITLE
Upgrade ruff to 0.9.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.9.1
     hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,8 +219,6 @@ ignore = [
     "Q003",
     "COM812",
     "COM819",
-    "ISC001",
-    "ISC002",
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]


### PR DESCRIPTION
Starting with ruff 0.9.1, rules `ISC001`/`ISC002` are [documented](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules) to be compatible with the ruff formatter, if they are both enabled. Enable them!

> When using Ruff as a formatter, we recommend avoiding the following lint rules:
> [...]
> [`multi-line-implicit-string-concatenation`](https://docs.astral.sh/ruff/rules/multi-line-implicit-string-concatenation/) (`ISC002`) if used without `ISC001` and `flake8-implicit-str-concat.allow-multiline = false`

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
