### PR TITLE
Minor UX improvement: Add the `UnknownCodecError`.

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -63,6 +63,8 @@ Improvements
   Import errors caused by optional dependencies (ZFPY, MsgPack, CRC32C, and PCodec)
   are still silently caught.
   By :user:`David Stansby <dstansby>`, :issue:`550`.
+* Raise a custom `UnknownCodecError` when trying to retrieve an unavailable codec.
+  By :user:`Cas Wognum <cwognum>`.
 
 
 0.14.1

--- a/numcodecs/errors.py
+++ b/numcodecs/errors.py
@@ -5,7 +5,7 @@ This module defines custom exceptions that are raised in the `numcodecs` codebas
 class UnknownCodecError(Exception):
     """
     An exception that is raised when trying to receive a codec that has not been registered.
-    
+
     Parameters
     ----------
     codec_id : str

--- a/numcodecs/errors.py
+++ b/numcodecs/errors.py
@@ -1,0 +1,17 @@
+"""
+This module defines custom exceptions that are raised in the `numcodecs` codebase.
+"""
+
+class UnknownCodecError(Exception):
+    """
+    An exception that is raised when trying to receive a codec that has not been registered.
+    
+    Parameters
+    ----------
+    codec_id : str
+        Codec identifier.
+    """
+
+    def __init__(self, codec_id: str):
+        self.codec_id = codec_id
+        super().__init__(f"codec not available: '{codec_id}'")

--- a/numcodecs/errors.py
+++ b/numcodecs/errors.py
@@ -11,6 +11,14 @@ class UnknownCodecError(Exception):
     ----------
     codec_id : str
         Codec identifier.
+
+    Examples
+    ----------
+    >>> import numcodecs
+    >>> numcodecs.get_codec({"codec_id": "unknown"})
+    Traceback (most recent call last):
+        ...
+    UnknownCodecError: codec not available: 'unknown'
     """
 
     def __init__(self, codec_id: str):

--- a/numcodecs/errors.py
+++ b/numcodecs/errors.py
@@ -2,6 +2,7 @@
 This module defines custom exceptions that are raised in the `numcodecs` codebase.
 """
 
+
 class UnknownCodecError(Exception):
     """
     An exception that is raised when trying to receive a codec that has not been registered.

--- a/numcodecs/errors.py
+++ b/numcodecs/errors.py
@@ -3,7 +3,7 @@ This module defines custom exceptions that are raised in the `numcodecs` codebas
 """
 
 
-class UnknownCodecError(Exception):
+class UnknownCodecError(ValueError):
     """
     An exception that is raised when trying to receive a codec that has not been registered.
 

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -5,6 +5,7 @@ import logging
 from importlib.metadata import EntryPoints, entry_points
 
 from numcodecs.abc import Codec
+from numcodecs.errors import UnknownCodecError
 
 logger = logging.getLogger("numcodecs")
 codec_registry: dict[str, Codec] = {}
@@ -50,7 +51,7 @@ def get_codec(config):
         register_codec(cls, codec_id=codec_id)
     if cls:
         return cls.from_config(config)
-    raise ValueError(f'codec not available: {codec_id!r}')
+    raise UnknownCodecError(f"{codec_id!r}")
 
 
 def register_codec(cls, codec_id=None):

--- a/numcodecs/tests/test_registry.py
+++ b/numcodecs/tests/test_registry.py
@@ -3,8 +3,8 @@ import inspect
 import pytest
 
 import numcodecs
-from numcodecs.registry import get_codec
 from numcodecs.errors import UnknownCodecError
+from numcodecs.registry import get_codec
 
 
 def test_registry_errors():

--- a/numcodecs/tests/test_registry.py
+++ b/numcodecs/tests/test_registry.py
@@ -4,10 +4,11 @@ import pytest
 
 import numcodecs
 from numcodecs.registry import get_codec
+from numcodecs.errors import UnknownCodecError
 
 
 def test_registry_errors():
-    with pytest.raises(ValueError):
+    with pytest.raises(UnknownCodecError):
         get_codec({'id': 'foo'})
 
 

--- a/numcodecs/tests/test_registry.py
+++ b/numcodecs/tests/test_registry.py
@@ -8,7 +8,7 @@ from numcodecs.registry import get_codec
 
 
 def test_registry_errors():
-    with pytest.raises(UnknownCodecError):
+    with pytest.raises(UnknownCodecError, match='foo'):
         get_codec({'id': 'foo'})
 
 


### PR DESCRIPTION
See https://github.com/zarr-developers/zarr-python/issues/2508 for context. 

Since `numcodecs` supports registering custom codecs in downstream libraries, there can be situations where the environment in which data was encoded is not the same as the environment in which the data is decoded (e.g. opening a Zarr archive that was created in a different environment). This can lead to missing codecs.

It would be a nice UX improvement if you catch that error and can offer codec specific solutions.
 
This change would enable something like: 

```py
import numcodecs

try: 
    numcodecs.get_codec({"codec_id": "imagecodecs_jpeg2k"})
except UnknownCodecError as error:
    if error.codec_id == "imagecodecs_jpeg2k":
        raise RuntimeError("This Zarr archive requires `imagecodecs`, to install it use ...") from error
```


TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
