### PR TITLE
(chore) type hints for tests

### DIFF
--- a/numcodecs/tests/test_astype.py
+++ b/numcodecs/tests/test_astype.py
@@ -20,13 +20,13 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr in arrays:
         codec = AsType(encode_dtype=arr.dtype, decode_dtype=arr.dtype)
         check_encode_decode(arr, codec)
 
 
-def test_decode():
+def test_decode() -> None:
     encode_dtype, decode_dtype = '<i4', '<i8'
     codec = AsType(encode_dtype=encode_dtype, decode_dtype=decode_dtype)
     arr = np.arange(10, 20, 1, dtype=encode_dtype)
@@ -36,7 +36,7 @@ def test_decode():
     assert np.dtype(decode_dtype) == actual.dtype
 
 
-def test_encode():
+def test_encode() -> None:
     encode_dtype, decode_dtype = '<i4', '<i8'
     codec = AsType(encode_dtype=encode_dtype, decode_dtype=decode_dtype)
     arr = np.arange(10, 20, 1, dtype=decode_dtype)
@@ -46,17 +46,17 @@ def test_encode():
     assert np.dtype(encode_dtype) == actual.dtype
 
 
-def test_config():
+def test_config() -> None:
     encode_dtype, decode_dtype = '<i4', '<i8'
     codec = AsType(encode_dtype=encode_dtype, decode_dtype=decode_dtype)
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("AsType(encode_dtype='<i4', decode_dtype='<i2')")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     # integers
     arrs = [
         np.arange(1000, dtype='<i4'),

--- a/numcodecs/tests/test_base64.py
+++ b/numcodecs/tests/test_base64.py
@@ -37,16 +37,16 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode(arr, codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("Base64()")
 
 
-def test_eq():
+def test_eq() -> None:
     assert Base64() == Base64()
     assert not Base64() != Base64()
     assert Base64() != "foo"
@@ -54,26 +54,26 @@ def test_eq():
     assert not Base64() == "foo"
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(Base64.codec_id, arrays, codecs)
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(Base64())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(Base64())
 
 
-def test_err_encode_list():
+def test_err_encode_list() -> None:
     data = ["foo", "bar", "baz"]
     for codec in codecs:
         with pytest.raises(TypeError):
             codec.encode(data)
 
 
-def test_err_encode_non_contiguous():
+def test_err_encode_non_contiguous() -> None:
     # non-contiguous memory
     arr = np.arange(1000, dtype="i4")[::2]
     for codec in codecs:

--- a/numcodecs/tests/test_bitround.py
+++ b/numcodecs/tests/test_bitround.py
@@ -8,18 +8,18 @@ from numcodecs.bitround import BitRound, max_bits
 
 # TODO: add other dtypes
 @pytest.fixture(params=["float32", "float64"])
-def dtype(request):
+def dtype(request: pytest.FixtureRequest) -> str:
     return request.param
 
 
-def round(data, keepbits):
+def round(data: np.ndarray, keepbits: int) -> np.ndarray:
     codec = BitRound(keepbits=keepbits)
     data = data.copy()  # otherwise overwrites the input
     encoded = codec.encode(data)
     return codec.decode(encoded)
 
 
-def test_round_zero_to_zero(dtype):
+def test_round_zero_to_zero(dtype: str) -> None:
     a = np.zeros((3, 2), dtype=dtype)
     # Don't understand Milan's original test:
     # How is it possible to have negative keepbits?
@@ -29,21 +29,21 @@ def test_round_zero_to_zero(dtype):
         np.testing.assert_equal(a, ar)
 
 
-def test_round_one_to_one(dtype):
+def test_round_one_to_one(dtype: str) -> None:
     a = np.ones((3, 2), dtype=dtype)
     for k in range(max_bits[dtype]):
         ar = round(a, k)
         np.testing.assert_equal(a, ar)
 
 
-def test_round_minus_one_to_minus_one(dtype):
+def test_round_minus_one_to_minus_one(dtype: str) -> None:
     a = -np.ones((3, 2), dtype=dtype)
     for k in range(max_bits[dtype]):
         ar = round(a, k)
         np.testing.assert_equal(a, ar)
 
 
-def test_no_rounding(dtype):
+def test_no_rounding(dtype: str) -> None:
     a = np.random.random_sample((300, 200)).astype(dtype)
     keepbits = max_bits[dtype]
     ar = round(a, keepbits)
@@ -53,7 +53,7 @@ def test_no_rounding(dtype):
 APPROX_KEEPBITS = {"float32": 11, "float64": 18}
 
 
-def test_approx_equal(dtype):
+def test_approx_equal(dtype: str) -> None:
     a = np.random.random_sample((300, 200)).astype(dtype)
     ar = round(a, APPROX_KEEPBITS[dtype])
     # Mimic julia behavior - https://docs.julialang.org/en/v1/base/math/#Base.isapprox
@@ -64,7 +64,7 @@ def test_approx_equal(dtype):
     np.testing.assert_allclose(a, ar, rtol=rtol)
 
 
-def test_idempotence(dtype):
+def test_idempotence(dtype: str) -> None:
     a = np.random.random_sample((300, 200)).astype(dtype)
     for k in range(20):
         ar = round(a, k)
@@ -72,7 +72,7 @@ def test_idempotence(dtype):
         np.testing.assert_equal(ar, ar2)
 
 
-def test_errors():
+def test_errors() -> None:
     with pytest.raises(ValueError):
         BitRound(keepbits=99).encode(np.array([0], dtype="float32"))
     with pytest.raises(TypeError):

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -58,19 +58,19 @@ arrays = [
 ]
 
 
-def _skip_null(codec):
+def _skip_null(codec: Blosc) -> None:
     if codec is None:
         pytest.skip("codec has been removed")
 
 
 @pytest.fixture(scope='module', params=[True, False, None])
-def use_threads(request):
+def use_threads(request: pytest.FixtureRequest) -> bool:
     return request.param
 
 
 @pytest.mark.parametrize('array', arrays)
 @pytest.mark.parametrize('codec', codecs)
-def test_encode_decode(array, codec):
+def test_encode_decode(array: np.ndarray, codec: Blosc) -> None:
     _skip_null(codec)
     check_encode_decode(array, codec)
 
@@ -83,19 +83,19 @@ def test_encode_decode(array, codec):
         for x in arrays
     ],
 )
-def test_partial_decode(codec, array):
+def test_partial_decode(codec: Blosc, array: np.ndarray) -> None:
     _skip_null(codec)
     check_encode_decode_partial(array, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = Blosc(cname='zstd', clevel=3, shuffle=1)
     check_config(codec)
     codec = Blosc(cname='lz4', clevel=1, shuffle=2, blocksize=2**8)
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     expect = "Blosc(cname='zstd', clevel=3, shuffle=SHUFFLE, blocksize=0)"
     actual = repr(Blosc(cname='zstd', clevel=3, shuffle=Blosc.SHUFFLE, blocksize=0))
     assert expect == actual
@@ -110,14 +110,14 @@ def test_repr():
     assert expect == actual
 
 
-def test_eq():
+def test_eq() -> None:
     assert Blosc() == Blosc()
     assert Blosc(cname='lz4') != Blosc(cname='zstd')
     assert Blosc(clevel=1) != Blosc(clevel=9)
     assert Blosc(cname='lz4') != 'foo'
 
 
-def test_compress_blocksize_default(use_threads):
+def test_compress_blocksize_default(use_threads: bool) -> None:
     arr = np.arange(1000, dtype='i4')
 
     blosc.use_threads = use_threads
@@ -134,7 +134,7 @@ def test_compress_blocksize_default(use_threads):
 
 
 @pytest.mark.parametrize('bs', [2**7, 2**8])
-def test_compress_blocksize(use_threads, bs):
+def test_compress_blocksize(use_threads: bool, bs: int) -> None:
     arr = np.arange(1000, dtype='i4')
 
     blosc.use_threads = use_threads
@@ -144,7 +144,7 @@ def test_compress_blocksize(use_threads, bs):
     assert blocksize == bs
 
 
-def test_compress_complib(use_threads):
+def test_compress_complib(use_threads: bool) -> None:
     arr = np.arange(1000, dtype='i4')
     expected_complibs = {
         'lz4': 'LZ4',
@@ -168,7 +168,7 @@ def test_compress_complib(use_threads):
 
 
 @pytest.mark.parametrize('dtype', ['i1', 'i2', 'i4', 'i8'])
-def test_compress_metainfo(dtype, use_threads):
+def test_compress_metainfo(dtype: str, use_threads: bool) -> None:
     arr = np.arange(1000, dtype=dtype)
     for shuffle in Blosc.NOSHUFFLE, Blosc.SHUFFLE, Blosc.BITSHUFFLE:
         blosc.use_threads = use_threads
@@ -179,7 +179,7 @@ def test_compress_metainfo(dtype, use_threads):
             assert did_shuffle == shuffle
 
 
-def test_compress_autoshuffle(use_threads):
+def test_compress_autoshuffle(use_threads: bool) -> None:
     arr = np.arange(8000)
     for dtype in 'i1', 'i2', 'i4', 'i8', 'f2', 'f4', 'f8', 'bool', 'S10':
         varr = arr.view(dtype)
@@ -194,7 +194,7 @@ def test_compress_autoshuffle(use_threads):
                 assert did_shuffle == Blosc.SHUFFLE
 
 
-def test_config_blocksize():
+def test_config_blocksize() -> None:
     # N.B., we want to be backwards compatible with any config where blocksize is not
     # explicitly stated
 
@@ -209,22 +209,22 @@ def test_config_blocksize():
     assert codec.blocksize == 2**8
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(Blosc.codec_id, arrays, codecs)
 
 
-def _encode_worker(data):
+def _encode_worker(data: np.ndarray) -> bytes:
     compressor = Blosc(cname='zlib', clevel=9, shuffle=Blosc.SHUFFLE)
     return compressor.encode(data)
 
 
-def _decode_worker(enc):
+def _decode_worker(enc: bytes) -> np.ndarray:
     compressor = Blosc()
     return compressor.decode(enc)
 
 
 @pytest.mark.parametrize('pool', [Pool, ThreadPool])
-def test_multiprocessing(use_threads, pool):
+def test_multiprocessing(use_threads: bool, pool: type) -> None:
     data = np.arange(1000000)
     enc = _encode_worker(data)
 
@@ -251,15 +251,15 @@ def test_multiprocessing(use_threads, pool):
         blosc.use_threads = None  # restore default
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(Blosc())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(Blosc())
 
 
-def test_decompression_error_handling():
+def test_decompression_error_handling() -> None:
     for codec in codecs:
         _skip_null(codec)
         with pytest.raises(RuntimeError):
@@ -268,7 +268,7 @@ def test_decompression_error_handling():
             codec.decode(bytearray(0))
 
 
-def test_max_buffer_size():
+def test_max_buffer_size() -> None:
     for codec in codecs:
         _skip_null(codec)
         assert codec.max_buffer_size == 2**31 - 1

--- a/numcodecs/tests/test_bz2.py
+++ b/numcodecs/tests/test_bz2.py
@@ -40,27 +40,27 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = BZ2(level=3)
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("BZ2(level=3)")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(BZ2.codec_id, arrays, codecs)
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(BZ2())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(BZ2())

--- a/numcodecs/tests/test_categorize.py
+++ b/numcodecs/tests/test_categorize.py
@@ -20,7 +20,7 @@ arrays = [
 arrays_object = [a.astype(object) for a in arrays]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     # unicode dtype
     for arr in arrays:
         codec = Categorize(labels, dtype=arr.dtype)
@@ -32,7 +32,7 @@ def test_encode_decode():
         check_encode_decode_array(arr, codec)
 
 
-def test_encode():
+def test_encode() -> None:
     for dtype in 'U', object:
         arr = np.array(['ƒöõ', 'ßàř', 'ƒöõ', 'ßāẑ', 'ƪùüx'], dtype=dtype)
         # miss off quux
@@ -52,12 +52,12 @@ def test_encode():
         assert arr.dtype == dec.dtype
 
 
-def test_config():
+def test_config() -> None:
     codec = Categorize(labels=labels, dtype='U4')
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     dtype = '<U3'
     astype = '|u1'
     codec = Categorize(labels=['foo', 'bar', 'baz', 'qux'], dtype=dtype, astype=astype)
@@ -73,14 +73,14 @@ def test_repr():
     assert expect == actual
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     codec = Categorize(labels=labels, dtype='<U4', astype='u1')
     check_backwards_compatibility(Categorize.codec_id, arrays, [codec], prefix='U')
     codec = Categorize(labels=labels, dtype=object, astype='u1')
     check_backwards_compatibility(Categorize.codec_id, arrays_object, [codec], prefix='O')
 
 
-def test_errors():
+def test_errors() -> None:
     with pytest.raises(TypeError):
         Categorize(labels=['foo', 'bar'], dtype='S6')
     with pytest.raises(TypeError):

--- a/numcodecs/tests/test_checksum32.py
+++ b/numcodecs/tests/test_checksum32.py
@@ -2,6 +2,7 @@ import itertools
 from contextlib import suppress
 
 import numpy as np
+from numcodecs.abc import Codec
 import pytest
 
 from numcodecs.checksum32 import CRC32, Adler32
@@ -55,31 +56,31 @@ if has_crc32c:
 
 
 @pytest.mark.parametrize(("codec", "arr"), itertools.product(codecs, arrays))
-def test_encode_decode(codec, arr):
+def test_encode_decode(codec: Codec, arr: np.ndarray) -> None:
     check_encode_decode(arr, codec)
 
 
 @pytest.mark.parametrize(("codec", "arr"), itertools.product(codecs, arrays))
-def test_errors(codec, arr):
+def test_errors(codec: Codec, arr: np.ndarray) -> None:
     enc = codec.encode(arr)
     with pytest.raises(RuntimeError):
         codec.decode(enc[:-1])
 
 
 @pytest.mark.parametrize("codec", codecs)
-def test_config(codec):
+def test_config(codec: Codec) -> None:
     check_config(codec)
 
 
 @pytest.mark.parametrize("codec", codecs)
-def test_err_input_too_small(codec):
+def test_err_input_too_small(codec: Codec) -> None:
     buf = b'000'  # 3 bytes are too little for a 32-bit checksum
     with pytest.raises(ValueError):
         codec.decode(buf)
 
 
 @pytest.mark.parametrize("codec", codecs)
-def test_err_encode_non_contiguous(codec):
+def test_err_encode_non_contiguous(codec: Codec) -> None:
     # non-contiguous memory
     arr = np.arange(1000, dtype='i4')[::2]
     with pytest.raises(ValueError):
@@ -87,13 +88,13 @@ def test_err_encode_non_contiguous(codec):
 
 
 @pytest.mark.parametrize("codec", codecs)
-def test_err_encode_list(codec):
+def test_err_encode_list(codec: Codec) -> None:
     data = ['foo', 'bar', 'baz']
     with pytest.raises(TypeError):
         codec.encode(data)
 
 
-def test_err_location():
+def test_err_location() -> None:
     with pytest.raises(ValueError):
         CRC32(location="foo")
     with pytest.raises(ValueError):
@@ -103,7 +104,7 @@ def test_err_location():
             CRC32C(location="foo")
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("CRC32(location='start')")
     check_repr("CRC32(location='end')")
     check_repr("Adler32(location='start')")
@@ -113,7 +114,7 @@ def test_repr():
         check_repr("CRC32C(location='end')")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(CRC32.codec_id, arrays, [CRC32()])
     check_backwards_compatibility(Adler32.codec_id, arrays, [Adler32()])
     if has_crc32c:
@@ -121,17 +122,17 @@ def test_backwards_compatibility():
 
 
 @pytest.mark.parametrize("codec", codecs)
-def test_err_encode_object_buffer(codec):
+def test_err_encode_object_buffer(codec: Codec) -> None:
     check_err_encode_object_buffer(codec)
 
 
 @pytest.mark.parametrize("codec", codecs)
-def test_err_decode_object_buffer(codec):
+def test_err_decode_object_buffer(codec: Codec) -> None:
     check_err_decode_object_buffer(codec)
 
 
 @pytest.mark.parametrize("codec", codecs)
-def test_err_out_too_small(codec):
+def test_err_out_too_small(codec: Codec) -> None:
     arr = np.arange(10, dtype='i4')
     out = np.empty_like(arr)[:-1]
     with pytest.raises(ValueError):
@@ -139,14 +140,14 @@ def test_err_out_too_small(codec):
 
 
 @pytest.mark.skipif(not has_crc32c, reason="Needs `crc32c` installed")
-def test_crc32c_checksum():
+def test_crc32c_checksum() -> None:
     arr = np.arange(0, 64, dtype="uint8")
     buf = CRC32C(location="end").encode(arr)
     assert np.frombuffer(buf, dtype="<u4", offset=(len(buf) - 4))[0] == np.uint32(4218238699)
 
 
 @pytest.mark.parametrize("codec", codecs)
-def test_err_checksum(codec):
+def test_err_checksum(codec: Codec) -> None:
     arr = np.arange(0, 64, dtype="uint8")
     buf = bytearray(codec.encode(arr))
     buf[-1] = 0  # corrupt the checksum

--- a/numcodecs/tests/test_compat.py
+++ b/numcodecs/tests/test_compat.py
@@ -7,7 +7,7 @@ import pytest
 from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray, ensure_text
 
 
-def test_ensure_text():
+def test_ensure_text() -> None:
     bufs = [
         b'adsdasdas',
         'adsdasdas',
@@ -19,7 +19,7 @@ def test_ensure_text():
         assert isinstance(b, str)
 
 
-def test_ensure_bytes():
+def test_ensure_bytes() -> None:
     bufs = [
         b'adsdasdas',
         bytes(20),
@@ -31,7 +31,7 @@ def test_ensure_bytes():
         assert isinstance(b, bytes)
 
 
-def test_ensure_contiguous_ndarray_shares_memory():
+def test_ensure_contiguous_ndarray_shares_memory() -> None:
     typed_bufs = [
         ('u', 1, b'adsdasdas'),
         ('u', 1, bytes(20)),
@@ -56,7 +56,7 @@ def test_ensure_contiguous_ndarray_shares_memory():
         assert np.shares_memory(a, memoryview(buf))
 
 
-def test_ensure_bytes_invalid_inputs():
+def test_ensure_bytes_invalid_inputs() -> None:
     # object array not allowed
     a = np.array(['Xin chào thế giới'], dtype=object)
     for e in (a, memoryview(a)):
@@ -67,7 +67,7 @@ def test_ensure_bytes_invalid_inputs():
 @pytest.mark.filterwarnings(
     "ignore:The 'u' type code is deprecated and will be removed in Python 3.16"
 )
-def test_ensure_contiguous_ndarray_invalid_inputs():
+def test_ensure_contiguous_ndarray_invalid_inputs() -> None:
     # object array not allowed
     a = np.array(['Xin chào thế giới'], dtype=object)
     for e in (a, memoryview(a)):
@@ -84,7 +84,7 @@ def test_ensure_contiguous_ndarray_invalid_inputs():
         ensure_contiguous_ndarray(a)
 
 
-def test_ensure_contiguous_ndarray_writeable():
+def test_ensure_contiguous_ndarray_writeable() -> None:
     # check that the writeability of the underlying buffer is preserved
     for writeable in (False, True):
         a = np.arange(100)
@@ -95,7 +95,7 @@ def test_ensure_contiguous_ndarray_writeable():
         assert m.flags.writeable == writeable
 
 
-def test_ensure_contiguous_ndarray_max_buffer_size():
+def test_ensure_contiguous_ndarray_max_buffer_size() -> None:
     for max_buffer_size in (4, 64, 1024):
         ensure_contiguous_ndarray(np.zeros(max_buffer_size - 1, dtype=np.int8), max_buffer_size)
         ensure_contiguous_ndarray(np.zeros(max_buffer_size, dtype=np.int8), max_buffer_size)

--- a/numcodecs/tests/test_delta.py
+++ b/numcodecs/tests/test_delta.py
@@ -22,13 +22,13 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr in arrays:
         codec = Delta(dtype=arr.dtype)
         check_encode_decode(arr, codec)
 
 
-def test_encode():
+def test_encode() -> None:
     dtype = 'i8'
     astype = 'i4'
     codec = Delta(dtype=dtype, astype=astype)
@@ -39,22 +39,22 @@ def test_encode():
     assert np.dtype(astype) == actual.dtype
 
 
-def test_config():
+def test_config() -> None:
     codec = Delta(dtype='<i4', astype='<i2')
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("Delta(dtype='<i4', astype='<i2')")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     for arr in arrays:
         codec = Delta(dtype=arr.dtype)
         check_backwards_compatibility(Delta.codec_id, [arr], [codec], prefix=str(arr.dtype))
 
 
-def test_errors():
+def test_errors() -> None:
     with pytest.raises(ValueError):
         Delta(dtype=object)
     with pytest.raises(ValueError):

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -9,7 +9,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 
 @pytest.fixture
-def set_path():
+def set_path() -> None:
     sys.path.append(here)
     numcodecs.registry.run_entrypoints()
     yield
@@ -19,6 +19,6 @@ def set_path():
 
 
 @pytest.mark.usefixtures("set_path")
-def test_entrypoint_codec():
+def test_entrypoint_codec() -> None:
     cls = numcodecs.registry.get_codec({"id": "test"})
     assert cls.codec_id == "test"

--- a/numcodecs/tests/test_entrypoints_backport.py
+++ b/numcodecs/tests/test_entrypoints_backport.py
@@ -17,7 +17,7 @@ if importlib_spec is None or importlib_spec.loader is None:  # pragma: no cover
 here = os.path.abspath(os.path.dirname(__file__))
 
 
-def get_entrypoints_with_importlib_metadata_loaded():
+def get_entrypoints_with_importlib_metadata_loaded() -> None:
     # importlib_metadata patches importlib.metadata, which can lead to breaking changes
     # to the APIs of EntryPoint objects used when registering entrypoints. Attempt to
     # isolate those changes to just this test.
@@ -29,7 +29,7 @@ def get_entrypoints_with_importlib_metadata_loaded():
     assert cls.codec_id == "test"
 
 
-def test_entrypoint_codec_with_importlib_metadata():
+def test_entrypoint_codec_with_importlib_metadata() -> None:
     p = Process(target=get_entrypoints_with_importlib_metadata_loaded)
     p.start()
     p.join()

--- a/numcodecs/tests/test_fixedscaleoffset.py
+++ b/numcodecs/tests/test_fixedscaleoffset.py
@@ -30,7 +30,7 @@ codecs = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         precision = int(np.log10(codec.scale))
         check_encode_decode(arr, codec, precision=precision)
@@ -44,7 +44,7 @@ def test_encode_decode():
         (1000, 0.5, [0, 0, 1, 1, 1, 1, 2, 2, 2, 2]),
     ],
 )
-def test_encode(offset: float, scale: float, expected: list[int]):
+def test_encode(offset: float, scale: float, expected: list[int]) -> None:
     dtype = '<f8'
     astype = np.int16
     codec = FixedScaleOffset(scale=scale, offset=offset, dtype=dtype, astype=astype)
@@ -55,22 +55,22 @@ def test_encode(offset: float, scale: float, expected: list[int]):
     assert np.dtype(astype) == actual.dtype
 
 
-def test_config():
+def test_config() -> None:
     codec = FixedScaleOffset(dtype='<f8', astype='<i4', scale=10, offset=100)
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     stmt = "FixedScaleOffset(scale=10, offset=100, dtype='<f8', astype='<i4')"
     check_repr(stmt)
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     precision = [int(np.log10(codec.scale)) for codec in codecs]
     check_backwards_compatibility(FixedScaleOffset.codec_id, arrays, codecs, precision=precision)
 
 
-def test_errors():
+def test_errors() -> None:
     with pytest.raises(ValueError):
         FixedScaleOffset(dtype=object, astype='i4', scale=10, offset=100)
     with pytest.raises(ValueError):

--- a/numcodecs/tests/test_fletcher32.py
+++ b/numcodecs/tests/test_fletcher32.py
@@ -5,14 +5,14 @@ from numcodecs.fletcher32 import Fletcher32
 
 
 @pytest.mark.parametrize("dtype", ["uint8", "int32", "float32"])
-def test_with_data(dtype):
+def test_with_data(dtype: str) -> None:
     data = np.arange(100, dtype=dtype)
     f = Fletcher32()
     arr = np.frombuffer(f.decode(f.encode(data)), dtype=dtype)
     assert (arr == data).all()
 
 
-def test_error():
+def test_error() -> None:
     data = np.arange(100)
     f = Fletcher32()
     enc = f.encode(data)
@@ -23,7 +23,7 @@ def test_error():
     assert "fletcher32 checksum" in str(e.value)
 
 
-def test_known():
+def test_known() -> None:
     data = (
         b'w\x07\x00\x00\x00\x00\x00\x00\x85\xf6\xff\xff\xff\xff\xff\xff'
         b'i\x07\x00\x00\x00\x00\x00\x00\x94\xf6\xff\xff\xff\xff\xff\xff'
@@ -49,7 +49,7 @@ def test_known():
     assert outarr.tolist() == expected
 
 
-def test_out():
+def test_out() -> None:
     data = np.frombuffer(bytearray(b"Hello World"), dtype="uint8")
     f = Fletcher32()
     result = f.encode(data)

--- a/numcodecs/tests/test_gzip.py
+++ b/numcodecs/tests/test_gzip.py
@@ -43,21 +43,21 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = GZip(level=3)
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("GZip(level=3)")
 
 
-def test_eq():
+def test_eq() -> None:
     assert GZip() == GZip()
     assert not GZip() != GZip()
     assert GZip(1) == GZip(1)
@@ -67,26 +67,26 @@ def test_eq():
     assert not GZip() == 'foo'
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(GZip.codec_id, arrays, codecs)
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(GZip())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(GZip())
 
 
-def test_err_encode_list():
+def test_err_encode_list() -> None:
     data = ['foo', 'bar', 'baz']
     for codec in codecs:
         with pytest.raises(TypeError):
             codec.encode(data)
 
 
-def test_err_encode_non_contiguous():
+def test_err_encode_non_contiguous() -> None:
     # non-contiguous memory
     arr = np.arange(1000, dtype='i4')[::2]
     for codec in codecs:
@@ -94,7 +94,7 @@ def test_err_encode_non_contiguous():
             codec.encode(arr)
 
 
-def test_err_out_too_small():
+def test_err_out_too_small() -> None:
     arr = np.arange(10, dtype='i4')
     out = np.empty_like(arr)[:-1]
     for codec in codecs:
@@ -102,7 +102,7 @@ def test_err_out_too_small():
             codec.decode(codec.encode(arr), out)
 
 
-def test_out_too_large():
+def test_out_too_large() -> None:
     out = np.empty((10,), dtype='i4')
     arr = out[:-1]
     arr[:] = 5

--- a/numcodecs/tests/test_jenkins.py
+++ b/numcodecs/tests/test_jenkins.py
@@ -5,7 +5,7 @@ from numcodecs.checksum32 import JenkinsLookup3
 from numcodecs.jenkins import jenkins_lookup3
 
 
-def test_jenkins_lookup3():
+def test_jenkins_lookup3() -> None:
     h = jenkins_lookup3(b"", 0)
     assert h == 0xDEADBEEF
     h = jenkins_lookup3(b"", 0xDEADBEEF)
@@ -62,7 +62,7 @@ def test_jenkins_lookup3():
     assert h == 0x17770551
 
 
-def test_jenkins_lookup3_codec():
+def test_jenkins_lookup3_codec() -> None:
     s = b"Four score and seven years ago"
     j = JenkinsLookup3()
     result = j.encode(s)
@@ -125,14 +125,14 @@ def test_jenkins_lookup3_codec():
 
 
 @pytest.mark.parametrize("dtype", ["uint8", "int32", "float32"])
-def test_with_data(dtype):
+def test_with_data(dtype: str) -> None:
     data = np.arange(100, dtype=dtype)
     j = JenkinsLookup3()
     arr = np.frombuffer(j.decode(j.encode(data)), dtype=dtype)
     assert (arr == data).all()
 
 
-def test_error():
+def test_error() -> None:
     data = np.arange(100)
     j = JenkinsLookup3()
     enc = j.encode(data)
@@ -143,7 +143,7 @@ def test_error():
     assert "Bob Jenkin's lookup3 checksum" in str(e.value)
 
 
-def test_out():
+def test_out() -> None:
     data = np.frombuffer(bytearray(b"Hello World"), dtype="uint8")
     j = JenkinsLookup3()
     result = j.encode(data)

--- a/numcodecs/tests/test_json.py
+++ b/numcodecs/tests/test_json.py
@@ -35,17 +35,17 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode_array(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     for codec in codecs:
         check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     r = (
         "JSON(encoding='utf-8', allow_nan=True, check_circular=True, ensure_ascii=True,\n"
         "     indent=None, separators=(',', ':'), skipkeys=False, sort_keys=True,\n"
@@ -54,7 +54,7 @@ def test_repr():
     check_repr(r)
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(JSON.codec_id, arrays, codecs)
 
 
@@ -76,7 +76,7 @@ def test_backwards_compatibility():
         (0, None),
     ],
 )
-def test_non_numpy_inputs(input_data, dtype):
+def test_non_numpy_inputs(input_data: list | int | dict, dtype: str | None) -> None:
     # numpy will infer a range of different shapes and dtypes for these inputs.
     # Make sure that round-tripping through encode preserves this.
     data = np.array(input_data, dtype=dtype)

--- a/numcodecs/tests/test_lz4.py
+++ b/numcodecs/tests/test_lz4.py
@@ -50,34 +50,34 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     for codec in codecs:
         check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("LZ4(acceleration=1)")
     check_repr("LZ4(acceleration=100)")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(LZ4.codec_id, arrays, codecs)
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(LZ4())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(LZ4())
 
 
-def test_max_buffer_size():
+def test_max_buffer_size() -> None:
     for codec in codecs:
         assert codec.max_buffer_size == 0x7E000000
         check_max_buffer_size(codec)

--- a/numcodecs/tests/test_lzma.py
+++ b/numcodecs/tests/test_lzma.py
@@ -53,40 +53,40 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = LZMA(preset=1, format=_lzma.FORMAT_XZ, check=_lzma.CHECK_NONE, filters=None)
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr('LZMA(format=1, check=0, preset=1, filters=None)')
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(LZMA.codec_id, arrays, codecs)
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(LZMA())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(LZMA())
 
 
-def test_err_encode_list():
+def test_err_encode_list() -> None:
     data = ['foo', 'bar', 'baz']
     for codec in codecs:
         with pytest.raises(TypeError):
             codec.encode(data)
 
 
-def test_err_encode_non_contiguous():
+def test_err_encode_non_contiguous() -> None:
     # non-contiguous memory
     arr = np.arange(1000, dtype='i4')[::2]
     for codec in codecs:

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -36,21 +36,21 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr in arrays:
         check_encode_decode_array(arr, MsgPack())
 
 
-def test_config():
+def test_config() -> None:
     check_config(MsgPack())
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("MsgPack(raw=False, use_bin_type=True, use_single_float=False)")
     check_repr("MsgPack(raw=True, use_bin_type=False, use_single_float=True)")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     codec = MsgPack()
     check_backwards_compatibility(codec.codec_id, arrays, [codec])
 
@@ -76,7 +76,7 @@ def test_backwards_compatibility():
         ([{b"key": b"value"}, [b"list", b"of", b"strings"]], object),
     ],
 )
-def test_non_numpy_inputs(input_data, dtype):
+def test_non_numpy_inputs(input_data: list, dtype: str | None) -> None:
     codec = MsgPack()
     # numpy will infer a range of different shapes and dtypes for these inputs.
     # Make sure that round-tripping through encode preserves this.
@@ -86,7 +86,7 @@ def test_non_numpy_inputs(input_data, dtype):
     assert np.array_equal(expect, actual)
 
 
-def test_encode_decode_shape_dtype_preserved():
+def test_encode_decode_shape_dtype_preserved() -> None:
     codec = MsgPack()
     for arr in arrays:
         actual = codec.decode(codec.encode(arr))
@@ -94,7 +94,7 @@ def test_encode_decode_shape_dtype_preserved():
         assert arr.dtype == actual.dtype
 
 
-def test_bytes():
+def test_bytes() -> None:
     # test msgpack behaviour with bytes and str (unicode)
     bytes_arr = np.array([b'foo', b'bar', b'baz'], dtype=object)
     unicode_arr = np.array(['foo', 'bar', 'baz'], dtype=object)

--- a/numcodecs/tests/test_ndarray_like.py
+++ b/numcodecs/tests/test_ndarray_like.py
@@ -4,43 +4,43 @@ from numcodecs.ndarray_like import DType, FlagsObj, NDArrayLike
 
 
 @pytest.mark.parametrize("module", ["numpy", "cupy"])
-def test_is_ndarray_like(module):
+def test_is_ndarray_like(module: str) -> None:
     m = pytest.importorskip(module)
     a = m.arange(10)
     assert isinstance(a, NDArrayLike)
 
 
-def test_is_not_ndarray_like():
+def test_is_not_ndarray_like() -> None:
     assert not isinstance([1, 2, 3], NDArrayLike)
     assert not isinstance(b"1,2,3", NDArrayLike)
 
 
 @pytest.mark.parametrize("module", ["numpy", "cupy"])
-def test_is_dtype_like(module):
+def test_is_dtype_like(module: str) -> None:
     m = pytest.importorskip(module)
     d = m.dtype("u8")
     assert isinstance(d, DType)
 
 
-def test_is_not_dtype_like():
+def test_is_not_dtype_like() -> None:
     assert not isinstance([1, 2, 3], DType)
     assert not isinstance(b"1,2,3", DType)
 
 
 @pytest.mark.parametrize("module", ["numpy", "cupy"])
-def test_is_flags_like(module):
+def test_is_flags_like(module: str) -> None:
     m = pytest.importorskip(module)
     d = m.arange(10).flags
     assert isinstance(d, FlagsObj)
 
 
-def test_is_not_flags_like():
+def test_is_not_flags_like() -> None:
     assert not isinstance([1, 2, 3], FlagsObj)
     assert not isinstance(b"1,2,3", FlagsObj)
 
 
 @pytest.mark.parametrize("module", ["numpy", "cupy"])
-def test_cached_isinstance_check(module):
+def test_cached_isinstance_check(module: str) -> None:
     m = pytest.importorskip(module)
     a = m.arange(10)
     assert isinstance(a, NDArrayLike)

--- a/numcodecs/tests/test_packbits.py
+++ b/numcodecs/tests/test_packbits.py
@@ -16,7 +16,7 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     codec = PackBits()
     for arr in arrays:
         check_encode_decode(arr, codec)
@@ -26,14 +26,14 @@ def test_encode_decode():
         check_encode_decode(arr[:size], codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = PackBits()
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("PackBits()")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(PackBits.codec_id, arrays, [PackBits()])

--- a/numcodecs/tests/test_pcodec.py
+++ b/numcodecs/tests/test_pcodec.py
@@ -48,29 +48,29 @@ arrays = [
 
 @pytest.mark.parametrize("arr", arrays)
 @pytest.mark.parametrize("codec", codecs)
-def test_encode_decode(arr, codec):
+def test_encode_decode(arr: np.ndarray, codec: PCodec) -> None:
     check_encode_decode_array_to_bytes(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = PCodec(level=3)
     check_config(codec)
 
 
 @pytest.mark.parametrize("param", ["mode_spec", "delta_spec", "paging_spec"])
-def test_invalid_config_error(param):
+def test_invalid_config_error(param: str) -> None:
     codec = PCodec(**{param: "bogus"})
     with pytest.raises(ValueError):
         check_encode_decode_array_to_bytes(arrays[0], codec)
 
 
-def test_invalid_delta_encoding_combo():
+def test_invalid_delta_encoding_combo() -> None:
     codec = PCodec(delta_encoding_order=2, delta_spec="none")
     with pytest.raises(ValueError):
         check_encode_decode_array_to_bytes(arrays[0], codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr(
         "PCodec(delta_encoding_order=None, delta_spec='auto',"
         " equal_pages_up_to=262144, level=3, mode_spec='auto',"
@@ -78,13 +78,13 @@ def test_repr():
     )
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(PCodec.codec_id, arrays, codecs)
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(PCodec())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(PCodec())

--- a/numcodecs/tests/test_pickles.py
+++ b/numcodecs/tests/test_pickles.py
@@ -31,19 +31,19 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode_array(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = Pickle(protocol=-1)
     check_config(codec)
     for codec in codecs:
         check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("Pickle(protocol=-1)")
 
 
@@ -57,5 +57,5 @@ def test_repr():
         "( https://github.com/zarr-developers/numcodecs/issues/271 )"
     ),
 )
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(Pickle.codec_id, arrays, codecs)

--- a/numcodecs/tests/test_quantize.py
+++ b/numcodecs/tests/test_quantize.py
@@ -30,12 +30,12 @@ codecs = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode(arr, codec, precision=codec.digits)
 
 
-def test_encode():
+def test_encode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         if arr.flags.f_contiguous:
             order = 'F'
@@ -45,7 +45,7 @@ def test_encode():
         assert_array_almost_equal(arr, enc, decimal=codec.digits)
 
 
-def test_decode():
+def test_decode() -> None:
     # decode is a no-op
     for arr, codec in itertools.product(arrays, codecs):
         enc = codec.encode(arr)
@@ -53,16 +53,16 @@ def test_decode():
         assert_array_equal(enc, dec)
 
 
-def test_config():
+def test_config() -> None:
     for codec in codecs:
         check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("Quantize(digits=2, dtype='<f8', astype='<f2')")
 
 
-def test_errors():
+def test_errors() -> None:
     with pytest.raises(ValueError):
         Quantize(digits=2, dtype='i4')
     with pytest.raises(ValueError):
@@ -71,6 +71,6 @@ def test_errors():
         Quantize(digits=2, dtype='f8', astype=object)
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     precision = [codec.digits for codec in codecs]
     check_backwards_compatibility(Quantize.codec_id, arrays, codecs, precision=precision)

--- a/numcodecs/tests/test_registry.py
+++ b/numcodecs/tests/test_registry.py
@@ -7,12 +7,12 @@ from numcodecs.errors import UnknownCodecError
 from numcodecs.registry import get_codec
 
 
-def test_registry_errors():
+def test_registry_errors() -> None:
     with pytest.raises(UnknownCodecError, match='foo'):
         get_codec({'id': 'foo'})
 
 
-def test_get_codec_argument():
+def test_get_codec_argument() -> None:
     # Check that get_codec doesn't modify its argument.
     arg = {"id": "json2"}
     before = dict(arg)
@@ -20,7 +20,7 @@ def test_get_codec_argument():
     assert before == arg
 
 
-def test_all_classes_registered():
+def test_all_classes_registered() -> None:
     """
     find all Codec subclasses in this repository and check that they
     have been registered.

--- a/numcodecs/tests/test_shuffle.py
+++ b/numcodecs/tests/test_shuffle.py
@@ -46,18 +46,18 @@ arrays = [
 
 @pytest.mark.parametrize('array', arrays)
 @pytest.mark.parametrize('codec', codecs)
-def test_encode_decode(array, codec):
+def test_encode_decode(array: np.ndarray, codec: Shuffle) -> None:
     check_encode_decode(array, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = Shuffle()
     check_config(codec)
     codec = Shuffle(elementsize=8)
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     expect = "Shuffle(elementsize=0)"
     actual = repr(Shuffle(elementsize=0))
     assert expect == actual
@@ -72,23 +72,23 @@ def test_repr():
     assert expect == actual
 
 
-def test_eq():
+def test_eq() -> None:
     assert Shuffle() == Shuffle()
     assert Shuffle(elementsize=16) != Shuffle()
 
 
-def _encode_worker(data):
+def _encode_worker(data: np.ndarray) -> bytes:
     compressor = Shuffle()
     return compressor.encode(data)
 
 
-def _decode_worker(enc):
+def _decode_worker(enc: bytes) -> np.ndarray:
     compressor = Shuffle()
     return compressor.decode(enc)
 
 
 @pytest.mark.parametrize('pool', [Pool, ThreadPool])
-def test_multiprocessing(pool):
+def test_multiprocessing(pool: type[Pool | ThreadPool]) -> None:
     data = np.arange(1000000)
     enc = _encode_worker(data)
 
@@ -109,7 +109,7 @@ def test_multiprocessing(pool):
     pool.join()
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(Shuffle.codec_id, arrays, codecs)
 
 
@@ -128,7 +128,7 @@ def test_backwards_compatibility():
 #             codec.decode(bytearray(0))
 
 
-def test_expected_result():
+def test_expected_result() -> None:
     # If the input is treated as a 2D byte array, with shape (size of element, number of elements),
     # the shuffle is essentially a transpose. This can be made more apparent by using an array of
     # big-endian integers, as below.
@@ -159,7 +159,7 @@ def test_expected_result():
     np.testing.assert_array_equal(np.frombuffer(enc.data, '>u4'), expected)
 
 
-def test_incompatible_elementsize():
+def test_incompatible_elementsize() -> None:
     arr = np.arange(1001, dtype='u1')
     codec = Shuffle(elementsize=4)
     with pytest.raises(ValueError):

--- a/numcodecs/tests/test_vlen_array.py
+++ b/numcodecs/tests/test_vlen_array.py
@@ -35,26 +35,25 @@ codecs = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr in arrays:
         for codec in codecs:
             check_encode_decode_array(arr, codec)
 
-
-def test_config():
+def test_config() -> None:
     codec = VLenArray('<i8')
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("VLenArray(dtype='<i8')")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(VLenArray.codec_id, arrays, codecs)
 
 
-def test_encode_errors():
+def test_encode_errors() -> None:
     codec = VLenArray('<i8')
     with pytest.raises(ValueError):
         codec.encode('foo')
@@ -62,7 +61,7 @@ def test_encode_errors():
         codec.encode(['foo', 'bar'])
 
 
-def test_decode_errors():
+def test_decode_errors() -> None:
     codec = VLenArray('<i8')
     with pytest.raises(TypeError):
         codec.decode(1234)
@@ -88,7 +87,7 @@ def test_decode_errors():
         codec.decode(enc, out=np.zeros(10, dtype='i4'))
 
 
-def test_encode_none():
+def test_encode_none() -> None:
     a = np.array([[1, 3], None, [4, 7]], dtype=object)
     codec = VLenArray(int)
     enc = codec.encode(a)

--- a/numcodecs/tests/test_vlen_bytes.py
+++ b/numcodecs/tests/test_vlen_bytes.py
@@ -29,26 +29,26 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr in arrays:
         codec = VLenBytes()
         check_encode_decode_array(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = VLenBytes()
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("VLenBytes()")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(VLenBytes.codec_id, arrays, [VLenBytes()])
 
 
-def test_encode_errors():
+def test_encode_errors() -> None:
     codec = VLenBytes()
     with pytest.raises(TypeError):
         codec.encode(1234)
@@ -58,7 +58,7 @@ def test_encode_errors():
         codec.encode(np.ones(10, dtype='i4'))
 
 
-def test_decode_errors():
+def test_decode_errors() -> None:
     codec = VLenBytes()
     with pytest.raises(TypeError):
         codec.decode(1234)
@@ -87,7 +87,7 @@ def test_decode_errors():
 # TODO: fix this test on GitHub actions somehow...
 # See https://github.com/zarr-developers/numcodecs/issues/683
 @pytest.mark.skip("Test is failing on GitHub actions.")
-def test_encode_none():
+def test_encode_none() -> None:
     a = np.array([b'foo', None, b'bar'], dtype=object)
     codec = VLenBytes()
     enc = codec.encode(a)

--- a/numcodecs/tests/test_vlen_utf8.py
+++ b/numcodecs/tests/test_vlen_utf8.py
@@ -24,26 +24,26 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr in arrays:
         codec = VLenUTF8()
         check_encode_decode_array(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = VLenUTF8()
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("VLenUTF8()")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(VLenUTF8.codec_id, arrays, [VLenUTF8()])
 
 
-def test_encode_errors():
+def test_encode_errors() -> None:
     codec = VLenUTF8()
     with pytest.raises(TypeError):
         codec.encode(1234)
@@ -53,7 +53,7 @@ def test_encode_errors():
         codec.encode(np.ones(10, dtype='i4'))
 
 
-def test_decode_errors():
+def test_decode_errors() -> None:
     codec = VLenUTF8()
     with pytest.raises(TypeError):
         codec.decode(1234)
@@ -80,7 +80,7 @@ def test_decode_errors():
 
 
 @pytest.mark.parametrize("writable", [True, False])
-def test_encode_utf8(writable):
+def test_encode_utf8(writable: bool) -> None:
     a = np.array(['foo', None, 'bar'], dtype=object)
     if not writable:
         a.setflags(write=False)

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -43,13 +43,13 @@ ALL_CODECS = [getattr(numcodecs.zarr3, cls_name) for cls_name in numcodecs.zarr3
 
 
 @pytest.mark.parametrize("codec_class", ALL_CODECS)
-def test_entry_points(codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
+def test_entry_points(codec_class: type[numcodecs.zarr3._NumcodecsCodec]) -> None:
     codec_name = codec_class.codec_name
     assert get_codec_class(codec_name) == codec_class
 
 
 @pytest.mark.parametrize("codec_class", ALL_CODECS)
-def test_docstring(codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
+def test_docstring(codec_class: type[numcodecs.zarr3._NumcodecsCodec]) -> None:
     assert "See :class:`numcodecs." in codec_class.__doc__  # type: ignore[operator]
 
 
@@ -68,7 +68,7 @@ def test_docstring(codec_class: type[numcodecs.zarr3._NumcodecsCodec]):
 )
 def test_generic_compressor(
     store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsBytesBytesCodec]
-):
+) -> None:
     data = np.arange(0, 256, dtype="uint16").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -104,7 +104,7 @@ def test_generic_filter(
     store: StorePath,
     codec_class: type[numcodecs.zarr3._NumcodecsArrayArrayCodec],
     codec_config: dict[str, JSON],
-):
+) -> None:
     data = np.linspace(0, 10, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -124,7 +124,7 @@ def test_generic_filter(
     np.testing.assert_array_equal(data, a[:, :])
 
 
-def test_generic_filter_bitround(store: StorePath):
+def test_generic_filter_bitround(store: StorePath) -> None:
     data = np.linspace(0, 1, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -142,7 +142,7 @@ def test_generic_filter_bitround(store: StorePath):
     assert np.allclose(data, a[:, :], atol=0.1)
 
 
-def test_generic_filter_quantize(store: StorePath):
+def test_generic_filter_quantize(store: StorePath) -> None:
     data = np.linspace(0, 10, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -160,7 +160,7 @@ def test_generic_filter_quantize(store: StorePath):
     assert np.allclose(data, a[:, :], atol=0.001)
 
 
-def test_generic_filter_packbits(store: StorePath):
+def test_generic_filter_packbits(store: StorePath) -> None:
     data = np.zeros((16, 16), dtype="bool")
     data[0:4, :] = True
 
@@ -201,7 +201,7 @@ def test_generic_filter_packbits(store: StorePath):
 )
 def test_generic_checksum(
     store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsBytesBytesCodec]
-):
+) -> None:
     data = np.linspace(0, 10, 256, dtype="float32").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -222,7 +222,7 @@ def test_generic_checksum(
 @pytest.mark.parametrize("codec_class", [numcodecs.zarr3.PCodec, numcodecs.zarr3.ZFPY])
 def test_generic_bytes_codec(
     store: StorePath, codec_class: type[numcodecs.zarr3._NumcodecsArrayBytesCodec]
-):
+) -> None:
     try:
         codec_class()._codec  # noqa: B018
     except ValueError as e:  # pragma: no cover
@@ -249,7 +249,7 @@ def test_generic_bytes_codec(
     np.testing.assert_array_equal(data, a[:, :])
 
 
-def test_delta_astype(store: StorePath):
+def test_delta_astype(store: StorePath) -> None:
     data = np.linspace(0, 10, 256, dtype="i8").reshape((16, 16))
 
     with pytest.warns(UserWarning, match=EXPECTED_WARNING_STR):
@@ -269,11 +269,11 @@ def test_delta_astype(store: StorePath):
     np.testing.assert_array_equal(data, a[:, :])
 
 
-def test_repr():
+def test_repr() -> None:
     codec = numcodecs.zarr3.LZ4(level=5)
     assert repr(codec) == "LZ4(codec_name='numcodecs.lz4', codec_config={'level': 5})"
 
 
-def test_to_dict():
+def test_to_dict() -> None:
     codec = numcodecs.zarr3.LZ4(level=5)
     assert codec.to_dict() == {"name": "numcodecs.lz4", "configuration": {"level": 5}}

--- a/numcodecs/tests/test_zarr3_import.py
+++ b/numcodecs/tests/test_zarr3_import.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 
-def test_zarr3_import():
+def test_zarr3_import() -> None:
     ERROR_MESSAGE_MATCH = "zarr 3.0.0 or later.*"
 
     try:

--- a/numcodecs/tests/test_zfpy.py
+++ b/numcodecs/tests/test_zfpy.py
@@ -45,7 +45,7 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr in arrays:
         if arr.dtype in (np.int32, np.int64):
             codec = [codecs[-1]]
@@ -55,16 +55,16 @@ def test_encode_decode():
             check_encode_decode_array(arr, code)
 
 
-def test_config():
+def test_config() -> None:
     for codec in codecs:
         check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("ZFPY(mode=4, tolerance=0.001, rate=-1, precision=-1)")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     for code in codecs:
         if code.mode == _zfpy.mode_fixed_rate:
             codec = [code]
@@ -73,22 +73,22 @@ def test_backwards_compatibility():
             check_backwards_compatibility(ZFPY.codec_id, arrays[: len(arrays) - 2], codecs)
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(ZFPY())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(ZFPY())
 
 
-def test_err_encode_list():
+def test_err_encode_list() -> None:
     data = ['foo', 'bar', 'baz']
     for codec in codecs:
         with pytest.raises(TypeError):
             codec.encode(data)
 
 
-def test_err_encode_non_contiguous():
+def test_err_encode_non_contiguous() -> None:
     # non-contiguous memory
     arr = np.arange(1000, dtype='i4')[::2]
     for codec in codecs:
@@ -96,7 +96,7 @@ def test_err_encode_non_contiguous():
             codec.encode(arr)
 
 
-def test_err_encode_fortran_array():
+def test_err_encode_fortran_array() -> None:
     # fortran array
     arr = np.asfortranarray(np.random.normal(loc=1000, scale=1, size=(5, 10, 20)))
     for codec in codecs:

--- a/numcodecs/tests/test_zlib.py
+++ b/numcodecs/tests/test_zlib.py
@@ -43,21 +43,21 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     codec = Zlib(level=3)
     check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("Zlib(level=3)")
 
 
-def test_eq():
+def test_eq() -> None:
     assert Zlib() == Zlib()
     assert not Zlib() != Zlib()
     assert Zlib(1) == Zlib(1)
@@ -67,26 +67,26 @@ def test_eq():
     assert not Zlib() == 'foo'
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(Zlib.codec_id, arrays, codecs)
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(Zlib())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(Zlib())
 
 
-def test_err_encode_list():
+def test_err_encode_list() -> None:
     data = ['foo', 'bar', 'baz']
     for codec in codecs:
         with pytest.raises(TypeError):
             codec.encode(data)
 
 
-def test_err_encode_non_contiguous():
+def test_err_encode_non_contiguous() -> None:
     # non-contiguous memory
     arr = np.arange(1000, dtype='i4')[::2]
     for codec in codecs:

--- a/numcodecs/tests/test_zstd.py
+++ b/numcodecs/tests/test_zstd.py
@@ -52,40 +52,40 @@ arrays = [
 ]
 
 
-def test_encode_decode():
+def test_encode_decode() -> None:
     for arr, codec in itertools.product(arrays, codecs):
         check_encode_decode(arr, codec)
 
 
-def test_config():
+def test_config() -> None:
     for codec in codecs:
         check_config(codec)
 
 
-def test_repr():
+def test_repr() -> None:
     check_repr("Zstd(level=3)")
 
 
-def test_backwards_compatibility():
+def test_backwards_compatibility() -> None:
     check_backwards_compatibility(Zstd.codec_id, arrays, codecs)
 
 
-def test_err_decode_object_buffer():
+def test_err_decode_object_buffer() -> None:
     check_err_decode_object_buffer(Zstd())
 
 
-def test_err_encode_object_buffer():
+def test_err_encode_object_buffer() -> None:
     check_err_encode_object_buffer(Zstd())
 
 
-def test_checksum():
+def test_checksum() -> None:
     data = np.arange(0, 64, dtype="uint8")
     assert len(Zstd(level=0, checksum=False).encode(data)) + 4 == len(
         Zstd(level=0, checksum=True).encode(data)
     )
 
 
-def test_native_functions():
+def test_native_functions() -> None:
     # Note, these assertions might need to be changed for new versions of zstd
     assert Zstd.default_level() == 3
     assert Zstd.min_level() == -131072


### PR DESCRIPTION
Adds type hints for test functions. They nearly all return `None`.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
