### PR TITLE
Unnecessary `None` provided as default

### DIFF
--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -271,7 +271,7 @@ class Shuffle(_NumcodecsBytesBytesCodec):
         super().__init__(**codec_config)
 
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> Shuffle:
-        if self.codec_config.get("elementsize", None) is None:
+        if self.codec_config.get("elementsize") is None:
             return Shuffle(**{**self.codec_config, "elementsize": array_spec.dtype.itemsize})
         return self  # pragma: no cover
 
@@ -308,7 +308,7 @@ class FixedScaleOffset(_NumcodecsArrayArrayCodec):
         return chunk_spec
 
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> FixedScaleOffset:
-        if self.codec_config.get("dtype", None) is None:
+        if self.codec_config.get("dtype") is None:
             return FixedScaleOffset(**{**self.codec_config, "dtype": str(array_spec.dtype)})
         return self
 
@@ -321,7 +321,7 @@ class Quantize(_NumcodecsArrayArrayCodec):
         super().__init__(**codec_config)
 
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> Quantize:
-        if self.codec_config.get("dtype", None) is None:
+        if self.codec_config.get("dtype") is None:
             return Quantize(**{**self.codec_config, "dtype": str(array_spec.dtype)})
         return self
 
@@ -356,7 +356,7 @@ class AsType(_NumcodecsArrayArrayCodec):
         return replace(chunk_spec, dtype=np.dtype(self.codec_config["encode_dtype"]))  # type: ignore[arg-type]
 
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> AsType:
-        if self.codec_config.get("decode_dtype", None) is None:
+        if self.codec_config.get("decode_dtype") is None:
             return AsType(**{**self.codec_config, "decode_dtype": str(array_spec.dtype)})
         return self
 


### PR DESCRIPTION
TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [x] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
