### PR TITLE
Only skip failing test on macOS

### DIFF
--- a/numcodecs/tests/test_vlen_bytes.py
+++ b/numcodecs/tests/test_vlen_bytes.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import unittest
 

--- a/numcodecs/tests/test_vlen_bytes.py
+++ b/numcodecs/tests/test_vlen_bytes.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import unittest
 
 import numpy as np
@@ -86,7 +88,7 @@ def test_decode_errors():
 
 # TODO: fix this test on GitHub actions somehow...
 # See https://github.com/zarr-developers/numcodecs/issues/683
-@pytest.mark.skip("Test is failing on GitHub actions.")
+@pytest.mark.skipif(sys.platform == "darwin", reason="Test is failing on macOS on GitHub actions.")
 def test_encode_none():
     a = np.array([b'foo', None, b'bar'], dtype=object)
     codec = VLenBytes()


### PR DESCRIPTION
I'm hoping this will allow the test to run and pass on Linux runners, and put our coverage up to 100% again so the PR list isn't full of ❌