### PR TITLE
Build for Linux AArch64 and other miscellaneous cleanups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
         # macos-13 is an intel runner, macos-14 is a arm64 runner
-        platform: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        platform: [ubuntu-latest, ubuntu-22.04-arm, windows-latest, macos-13, macos-14]
 
     defaults:
       run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0 # required for version resolution
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3.1.0
+        uses: conda-incubator/setup-miniconda@v3.1.1
         with:
           channels: conda-forge
           miniforge-version: latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        # macos-13 is an intel runner, macos-14 is a arm64 runner
+        # macos-13 is an intel runner, macos-14 is an arm64 runner
         platform: [ubuntu-latest, ubuntu-22.04-arm, windows-latest, macos-13, macos-14]
 
     defaults:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,8 +56,7 @@ jobs:
         # Since zarr v3 requires numpy >= 1.25, on Python 3.11 leave it out
         # so we can have some tests of our minimum version of numpy (1.24)
         if: matrix.python-version != '3.11'
-        # TODO: remove --pre option when zarr v3 is out
-        run: python -m pip install --pre zarr>=3.0.0b2
+        run: python -m pip install zarr>=3
 
       - name: List installed packages
         run: python -m pip list

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is a arm64 runner
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-22.04-arm, windows-latest, macos-13, macos-14]
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"
       CIBW_BUILD: "cp311-* cp312-* cp313-*"

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 is an intel runner, macos-14 is a arm64 runner
+        # macos-13 is an intel runner, macos-14 is an arm64 runner
         os: [ubuntu-latest, ubuntu-22.04-arm, windows-latest, macos-13, macos-14]
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -17,6 +17,12 @@ Release notes
 Unreleased
 ----------
 
+Enhancements
+~~~~~~~~~~~~
+
+* Add support for the Linux AArch64 architecture.
+  By :user:`Agriya Khetarpal <agriyakhetarpal>`, :issue:`288`.
+
 Improvements
 ~~~~~~~~~~~~
 * Raise a custom `UnknownCodecError` when trying to retrieve an unavailable codec.
@@ -40,7 +46,7 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
-The following ``blosc`` funcitons are deprecated, with no replacement.
+The following ``blosc`` functions are deprecated, with no replacement.
 This is because they are not intended to be public API.
 
 - ``numcodecs.blosc.init``

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -20,7 +20,8 @@ Unreleased
 Enhancements
 ~~~~~~~~~~~~
 
-* Add support for the Linux AArch64 architecture.
+* Add support for the Linux AArch64 architecture, and bump the minimum
+macOS deployment target for x86_64 to 10.13.
   By :user:`Agriya Khetarpal <agriyakhetarpal>`, :issue:`288`.
 
 Improvements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,9 @@ filterwarnings = [
 [tool.cibuildwheel]
 environment = { DISABLE_NUMCODECS_AVX2=1 }
 [tool.cibuildwheel.macos]
-environment = { MACOSX_DEPLOYMENT_TARGET=10.9, DISABLE_NUMCODECS_AVX2=1, CFLAGS="$CFLAGS -Wno-implicit-function-declaration" }
+# cibuildwheel uses 3.12 for the Python driver, which supports High Sierra and later
+# https://github.com/pypa/cibuildwheel/blob/ee63bf16da6cddfb925f542f2c7b59ad50e93969/action.yml#L31
+environment = { MACOSX_DEPLOYMENT_TARGET=10.13, DISABLE_NUMCODECS_AVX2=1, CFLAGS="$CFLAGS -Wno-implicit-function-declaration" }
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 environment = { DISABLE_NUMCODECS_AVX2=1, DISABLE_NUMCODECS_SSE2=1 }

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,15 @@ from setuptools.errors import CCompilerError, ExecError, PlatformError
 # determine CPU support for SSE2 and AVX2
 cpu_info = cpuinfo.get_cpu_info()
 flags = cpu_info.get('flags', [])
-have_sse2 = 'sse2' in flags
-have_avx2 = 'avx2' in flags
+machine = cpuinfo.platform.machine()
+
+# only check for x86 features on x86_64 arch
+have_sse2 = False
+have_avx2 = False
+if machine == 'x86_64':
+    have_sse2 = 'sse2' in flags
+    have_avx2 = 'avx2' in flags
+
 disable_sse2 = 'DISABLE_NUMCODECS_SSE2' in os.environ
 disable_avx2 = 'DISABLE_NUMCODECS_AVX2' in os.environ
 
@@ -24,7 +31,7 @@ base_compile_args = []
 if have_cflags:
     # respect compiler options set by user
     pass
-elif os.name == 'posix':
+elif os.name == 'posix' and machine == 'x86_64':
     if disable_sse2:
         base_compile_args.append('-mno-sse2')
     elif have_sse2:

--- a/setup.py
+++ b/setup.py
@@ -302,13 +302,24 @@ class BuildFailed(Exception):
     pass
 
 
+def get_arch_specific_objects():
+    machine = cpuinfo.platform.machine()
+    if machine == 'x86_64':
+        return [S[:-1] + 'o' for S in glob("c-blosc/internal-complibs/zstd*/decompress/*amd64.S")]
+    elif machine == 'aarch64':
+        return [S[:-1] + 'o' for S in glob("c-blosc/internal-complibs/zstd*/decompress/*aarch64.S")]
+    return []
+
+
 class ve_build_ext(build_ext):
     # This class allows C extension building to fail.
 
     def run(self):
         try:
-            if cpuinfo.platform.machine() == 'x86_64':
-                S_files = glob('c-blosc/internal-complibs/zstd*/decompress/*amd64.S')
+            machine = cpuinfo.platform.machine()
+            if machine in ('x86_64', 'aarch64'):
+                pattern = '*amd64.S' if machine == 'x86_64' else '*aarch64.S'
+                S_files = glob(f'c-blosc/internal-complibs/zstd*/decompress/{pattern}')
                 compiler = ccompiler.new_compiler()
                 customize_compiler(compiler)
                 compiler.src_extensions.append('.S')

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,13 @@ def blosc_extension():
     info('setting up Blosc extension')
 
     extra_compile_args = base_compile_args.copy()
+    extra_link_args = []
     define_macros = []
+
+    # ensure pthread is properly linked on POSIX systems
+    if os.name == 'posix':
+        extra_compile_args.append('-pthread')
+        extra_link_args.append('-pthread')
 
     # setup blosc sources
     blosc_sources = [f for f in glob('c-blosc/blosc/*.c') if 'avx2' not in f and 'sse2' not in f]
@@ -125,6 +131,7 @@ def blosc_extension():
             include_dirs=include_dirs,
             define_macros=define_macros,
             extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args,
             extra_objects=extra_objects,
         ),
     ]

--- a/setup.py
+++ b/setup.py
@@ -316,15 +316,6 @@ class BuildFailed(Exception):
     pass
 
 
-def get_arch_specific_objects():
-    machine = cpuinfo.platform.machine()
-    if machine == 'x86_64':
-        return [S[:-1] + 'o' for S in glob("c-blosc/internal-complibs/zstd*/decompress/*amd64.S")]
-    elif machine == 'aarch64':
-        return [S[:-1] + 'o' for S in glob("c-blosc/internal-complibs/zstd*/decompress/*aarch64.S")]
-    return []
-
-
 class ve_build_ext(build_ext):
     # This class allows C extension building to fail.
 


### PR DESCRIPTION
This PR closes #288; it adds the new ubuntu-22.04-arm runner to build Linux AArch64/arm64 wheels. SSE2 and AVX2 x86-specific SIMD optimizations have been disabled at build time. This is in line with Spack downstream: https://github.com/spack/spack/pull/40754. Additionally, the minimum macOS deployment target has been bumped from 10.9 to 10.13 (High Sierra), as CPython supports 10.13+ post 3.12.6, which is used by `cibuildwheel`'s GitHub Action.

I've moved some code in `setup.py` to dedicated functions for now, but I agree with the direction in https://github.com/zarr-developers/numcodecs/issues/464 wherein moving to a more modern build system in comparison to `setuptools` has been suggested; it sounds like a better long-term solution.

Additional context: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [x] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
