### PR TITLE
Make Checksum32 an ABC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,8 @@ name = "numcodecs"
 description = """
 A Python package providing buffer compression and transformation codecs \
 for use in data storage and communication applications."""
-readme =  "README.rst"
-dependencies = [
-    "numpy>=1.24",
-    "deprecated"
-]
+readme = "README.rst"
+dependencies = ["numpy>=1.24", "deprecated", "typing_extensions"]
 requires-python = ">=3.11"
 dynamic = [
   "version",


### PR DESCRIPTION
Since it's not intended to be used without sub-classing, make `Checksum32` an ABC. This also means we can catch any sub-classes that don't implement `checksum()` more easily.