### PR TITLE
(feat): `typesize` declared with constructor for `Blosc`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -63,7 +63,10 @@ Improvements
   Import errors caused by optional dependencies (ZFPY, MsgPack, CRC32C, and PCodec)
   are still silently caught.
   By :user:`David Stansby <dstansby>`, :issue:`550`.
-
+* Add ``typesize`` argument to ``Blosc`` to allow for buffers that are passed to ``encode``
+  use that information.  zarr v3 currently has its Blosc codec as bytes-to-bytes but does retain
+  the size information so using it here allows for massive compression ratio gains.
+  By :user:`Ilan Gold <ilan-gold>`
 
 0.14.1
 ------

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -279,7 +279,9 @@ def compress(source, char* cname, int clevel, int shuffle=SHUFFLE,
     source_buffer = Buffer(source, PyBUF_ANY_CONTIGUOUS)
     source_ptr = source_buffer.ptr
     nbytes = source_buffer.nbytes
-    if typesize is not None:
+    if isinstance(typesize, int):
+        if typesize < 1:
+            raise ValueError(f"Cannot use typesize {typesize} less than 1.")
         itemsize = typesize
     else:
         itemsize = source_buffer.itemsize
@@ -572,6 +574,8 @@ class Blosc(Codec):
     max_buffer_size = 2**31 - 1
 
     def __init__(self, cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=AUTOBLOCKS, typesize=None):
+        if isinstance(typesize, int) and typesize < 1:
+            raise ValueError(f"Cannot use typesize {typesize} less than 1.")
         self.cname = cname
         if isinstance(cname, str):
             self._cname_bytes = cname.encode('ascii')

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -280,7 +280,7 @@ def compress(source, char* cname, int clevel, int shuffle=SHUFFLE,
     source_ptr = source_buffer.ptr
     nbytes = source_buffer.nbytes
     if isinstance(typesize, int):
-        if typesize < 1:
+        if typesize < 1: # pragma: no cover
             raise ValueError(f"Cannot use typesize {typesize} less than 1.")
         itemsize = typesize
     else:

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -280,7 +280,7 @@ def compress(source, char* cname, int clevel, int shuffle=SHUFFLE,
     source_ptr = source_buffer.ptr
     nbytes = source_buffer.nbytes
     if isinstance(typesize, int):
-        if typesize < 1: # pragma: no cover
+        if typesize < 1:
             raise ValueError(f"Cannot use typesize {typesize} less than 1.")
         itemsize = typesize
     else:

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -555,6 +555,8 @@ class Blosc(Codec):
     blocksize : int
         The requested size of the compressed blocks.  If 0 (default), an automatic
         blocksize will be used.
+    typesize : int, optional
+        The size in bytes of uncompressed array elements.
 
     See Also
     --------

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -235,7 +235,7 @@ def _err_bad_cname(cname):
 err_bad_cname = deprecated(_err_bad_cname)
 
 def compress(source, char* cname, int clevel, int shuffle=SHUFFLE,
-             int blocksize=AUTOBLOCKS):
+             int blocksize=AUTOBLOCKS, typesize=None):
     """Compress data.
 
     Parameters
@@ -279,7 +279,10 @@ def compress(source, char* cname, int clevel, int shuffle=SHUFFLE,
     source_buffer = Buffer(source, PyBUF_ANY_CONTIGUOUS)
     source_ptr = source_buffer.ptr
     nbytes = source_buffer.nbytes
-    itemsize = source_buffer.itemsize
+    if typesize is not None:
+        itemsize = typesize
+    else:
+        itemsize = source_buffer.itemsize
 
     # determine shuffle
     if shuffle == AUTOSHUFFLE:
@@ -566,7 +569,7 @@ class Blosc(Codec):
     AUTOSHUFFLE = AUTOSHUFFLE
     max_buffer_size = 2**31 - 1
 
-    def __init__(self, cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=AUTOBLOCKS):
+    def __init__(self, cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=AUTOBLOCKS, typesize=None):
         self.cname = cname
         if isinstance(cname, str):
             self._cname_bytes = cname.encode('ascii')
@@ -575,10 +578,11 @@ class Blosc(Codec):
         self.clevel = clevel
         self.shuffle = shuffle
         self.blocksize = blocksize
+        self.typesize = typesize
 
     def encode(self, buf):
         buf = ensure_contiguous_ndarray(buf, self.max_buffer_size)
-        return compress(buf, self._cname_bytes, self.clevel, self.shuffle, self.blocksize)
+        return compress(buf, self._cname_bytes, self.clevel, self.shuffle, self.blocksize, self.typesize)
 
     def decode(self, buf, out=None):
         buf = ensure_contiguous_ndarray(buf, self.max_buffer_size)

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -274,6 +274,7 @@ def test_max_buffer_size():
         assert codec.max_buffer_size == 2**31 - 1
         check_max_buffer_size(codec)
 
+
 def test_typesize_explicit():
     arr = np.arange(100).astype("int64")
     itemsize = arr.itemsize
@@ -281,5 +282,6 @@ def test_typesize_explicit():
     codec_itemsize = Blosc(shuffle=Blosc.SHUFFLE, typesize=itemsize)
     encoded_without_itemsize = codec_no_type_size.encode(arr.tobytes())
     encoded_with_itemsize = codec_itemsize.encode(arr.tobytes())
-    assert encoded_without_itemsize[3] == 1 # inferred from bytes i.e., 1
-    assert encoded_with_itemsize[3] == itemsize # given as a constructor argument
+    # third byte encodes the `typesize`
+    assert encoded_without_itemsize[3] == 1  # inferred from bytes i.e., 1
+    assert encoded_with_itemsize[3] == itemsize  # given as a constructor argument

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -273,3 +273,13 @@ def test_max_buffer_size():
         _skip_null(codec)
         assert codec.max_buffer_size == 2**31 - 1
         check_max_buffer_size(codec)
+
+def test_typesize_explicit():
+    arr = np.arange(100).astype("int64")
+    itemsize = arr.itemsize
+    codec_no_type_size = Blosc(shuffle=Blosc.SHUFFLE)
+    codec_itemsize = Blosc(shuffle=Blosc.SHUFFLE, typesize=itemsize)
+    encoded_without_itemsize = codec_no_type_size.encode(arr.tobytes())
+    encoded_with_itemsize = codec_itemsize.encode(arr.tobytes())
+    assert encoded_without_itemsize[3] == 1 # inferred from bytes i.e., 1
+    assert encoded_with_itemsize[3] == itemsize # given as a constructor argument

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -290,3 +290,9 @@ def test_typesize_explicit():
 def test_typesize_less_than_1():
     with pytest.raises(ValueError, match=r"Cannot use typesize"):
         Blosc(shuffle=Blosc.SHUFFLE, typesize=0)
+    compressor = Blosc(shuffle=Blosc.SHUFFLE)
+    # not really something that should be done in practice, but good for testing.
+    compressor.typesize = 0
+    arr = np.arange(100)
+    with pytest.raises(ValueError, match=r"Cannot use typesize"):
+        compressor.encode(arr.tobytes())

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -285,3 +285,8 @@ def test_typesize_explicit():
     # third byte encodes the `typesize`
     assert encoded_without_itemsize[3] == 1  # inferred from bytes i.e., 1
     assert encoded_with_itemsize[3] == itemsize  # given as a constructor argument
+
+
+def test_typesize_less_than_1():
+    with pytest.raises(ValueError, match=r"Cannot use typesize"):
+        Blosc(shuffle=Blosc.SHUFFLE, typesize=0)


### PR DESCRIPTION
See https://github.com/zarr-developers/zarr-python/issues/2766 and https://github.com/zarr-developers/zarr-python/issues/2171 - I checked locally the reproducer in the later for the compression ratio, and we now are getting the old performance with 1383 bytes

I think a good place to start is to declare the itemsize information, which is stored anyway on the `BloscCodec`

This PR does no validation of `typesize`, although it could in theory if the incoming buffer is a numpy array.  I'm not sure that's desireable though as this is purely a performance thing (i.e., a "wrong" `typesize` doesn't actually break compression/decompression). If you're so low-level that you're changing this while using arrays, and you get it wrong, you'd probably also notice that your files have bad compression ratios

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
