### PR TITLE
In `vlen`, define and use `const` `HEADER_LENGTH`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,6 +14,25 @@ Release notes
 
 .. _unreleased:
 
+Unreleased
+----------
+
+Enhancements
+~~~~~~~~~~~~
+
+Improvements
+~~~~~~~~~~~~
+
+* In ``vlen``, define and use ``const`` ``HEADER_LENGTH``.
+  By :user:`John Kirkham <jakirkham>`, :issue:`723`
+
+Fixes
+~~~~~
+
+Maintenance
+~~~~~~~~~~~
+
+
 0.16.0
 ------
 


### PR DESCRIPTION
Previously `HEADER_LENGTH` was defined in `vlen`, but not as `const`. So it could concievably be changed. While this didn't happen in practice, it does mean the compiler needs to generate code to check and use this value throughout.

However `HEADER_LENGTH` is intended to be `const`. So define it as such. That way the compiler can generate more efficient code when using it. Further define it in terms of the type whose size it references (namely `uint32_t`). Also make sure that type is `cimport`ed for referencing.

Finally consistently use `HEADER_LENGTH` when it applies throughout `vlen`. Previously `HEADER_LENGTH` was sometimes used and in other cases the value `4` was used. So consistently use `HEADER_LENGTH` throughout for improved code clarity. Now that `HEADER_LENGTH` is marked `const` this is equally efficient.

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
