### PR TITLE
Fix `const` discard warnings in `fletcher32`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,6 +14,25 @@ Release notes
 
 .. _unreleased:
 
+Unreleased
+----------
+
+Enhancements
+~~~~~~~~~~~~
+
+Improvements
+~~~~~~~~~~~~
+
+Fixes
+~~~~~
+
+* Fix ``const`` discard warnings in ``fletcher32``.
+  By :user:`John Kirkham <jakirkham>`, :issue:`728`
+
+Maintenance
+~~~~~~~~~~~
+
+
 0.16.0
 ------
 

--- a/numcodecs/fletcher32.pyx
+++ b/numcodecs/fletcher32.pyx
@@ -76,7 +76,7 @@ class Fletcher32(Codec):
         """Return buffer plus a footer with the fletcher checksum (4-bytes)"""
         buf = ensure_contiguous_ndarray(buf).ravel().view('uint8')
         cdef const uint8_t[::1] b_mv = buf
-        cdef uint8_t* b_ptr = &b_mv[0]
+        cdef const uint8_t* b_ptr = &b_mv[0]
         cdef Py_ssize_t b_len = len(b_mv)
 
         cdef Py_ssize_t out_len = b_len + FOOTER_LENGTH
@@ -92,7 +92,7 @@ class Fletcher32(Codec):
         """Check fletcher checksum, and return buffer without it"""
         b = ensure_contiguous_ndarray(buf).view('uint8')
         cdef const uint8_t[::1] b_mv = b
-        cdef uint8_t* b_ptr = &b_mv[0]
+        cdef const uint8_t* b_ptr = &b_mv[0]
         cdef Py_ssize_t b_len = len(b_mv)
 
         val = _fletcher32(b_mv[:-FOOTER_LENGTH])


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/numcodecs/issues/725

When accessing a pointer from a `const` typed-memoryview, make sure the pointer itself is also typed as `const` to avoid compiler warnings about discarding `const`.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
