### PR TITLE
Update ``license*`` metadata and include third-party licenses

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,6 +14,25 @@ Release notes
 
 .. _unreleased:
 
+Unreleased
+----------
+
+Enhancements
+~~~~~~~~~~~~
+
+Improvements
+~~~~~~~~~~~~
+
+Fixes
+~~~~~
+
+* Update ``license*`` metadata and include third-party licenses.
+  By :user:`John Kirkham <jakirkham>`, :issue:`729`
+
+Maintenance
+~~~~~~~~~~~
+
+
 0.16.0
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: Unix",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=64",
+    "setuptools>=77",
     "setuptools-scm[toml]>=6.2",
     "Cython",
     "py-cpuinfo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ maintainers = [
     { name = "Alistair Miles", email = "alimanfoo@googlemail.com" },
 ]
 license = "MIT"
+license-files = [
+    "LICENSE.txt",
+]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/zarr-developers/numcodecs/issues"
@@ -94,7 +97,6 @@ crc32c = [
 "numcodecs.zfpy" = "numcodecs.zarr3:ZFPY"
 
 [tool.setuptools]
-license-files = ["LICENSE.txt"]
 package-dir = {"" = "."}
 packages = ["numcodecs", "numcodecs.tests"]
 zip-safe = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ maintainers = [
 license = "MIT"
 license-files = [
     "LICENSE.txt",
+    "c-blosc/LICENSE.txt",
+    "c-blosc/LICENSES/*",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 maintainers = [
     { name = "Alistair Miles", email = "alimanfoo@googlemail.com" },
 ]
-license = { text = "MIT" }
+license = "MIT"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/zarr-developers/numcodecs/issues"


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/numcodecs/issues/724

Makes a few fixes to license metadata and packaging:

* Switch to using SPDX metadata for `license`
* Migrate to `project.license-files` for packaging license files
* Include 3rd party license files
* Drop deprecated trove-classifier for license

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
