### PR TITLE
[WIP] Test without entrypoint

### DIFF
--- a/numcodecs/tests/package_without_entrypoint-0.1.dist-info/entry_points.txt
+++ b/numcodecs/tests/package_without_entrypoint-0.1.dist-info/entry_points.txt
@@ -1,0 +1,1 @@
+[numcodecs.codecs]

--- a/numcodecs/tests/package_without_entrypoint/__init__.py
+++ b/numcodecs/tests/package_without_entrypoint/__init__.py
@@ -1,0 +1,1 @@
+from numcodecs.abc import Codec

--- a/numcodecs/tests/test_entrypoints.py
+++ b/numcodecs/tests/test_entrypoints.py
@@ -18,6 +18,11 @@ def set_path():
     numcodecs.registry.codec_registry.pop("test")
 
 
+def test_no_entrypoint_codec():
+    cls = numcodecs.registry.get_codec({"id": "test"})
+    assert cls.codec_id == "test"
+
+
 @pytest.mark.usefixtures("set_path")
 def test_entrypoint_codec():
     cls = numcodecs.registry.get_codec({"id": "test"})


### PR DESCRIPTION
Add a test with no entrypoints. This helps ensure the same code used to detect entrypoints works ok if it finds none (a common case).

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
