### PR TITLE
Add `#ifndef` guard around `PyBytes_RESIZE`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -32,6 +32,9 @@ Fixes
 * Fix ``const`` discard warnings in ``fletcher32``.
   By :user:`John Kirkham <jakirkham>`, :issue:`728`
 
+* Add ``#ifdef`` guard around ``PyBytes_RESIZE``.
+  By :user:`John Kirkham <jakirkham>`, :issue:`731`
+
 Maintenance
 ~~~~~~~~~~~
 

--- a/numcodecs/compat_ext.pxd
+++ b/numcodecs/compat_ext.pxd
@@ -3,7 +3,9 @@
 
 cdef extern from *:
     """
+    #ifndef PyBytes_RESIZE
     #define PyBytes_RESIZE(b, n) _PyBytes_Resize(&b, n)
+    #endif
     """
     int PyBytes_RESIZE(object b, Py_ssize_t n) except -1
 


### PR DESCRIPTION
Ensure `PyBytes_RESIZE` is not accidentally redefined by placing it inside an `#ifndef`/`#endif` guard block.

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
