### PR TITLE
Update development practices

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -203,12 +203,11 @@ contributors.
 Merging pull requests
 ~~~~~~~~~~~~~~~~~~~~~
 
-Pull requests submitted by an external contributor should be reviewed and approved by at least
-one core developers before being merged. Ideally, pull requests submitted by a core developer
-should be reviewed and approved by at least one other core developers before being merged.
+Pull requests should be reviewed and approved by at least one core developer
+(other than the pull request author) before being merged.
 
-Pull requests should not be merged until all CI checks have passed (Travis, AppVeyor,
-Codecov) against code that has had the latest main merged in.
+Pull requests should not be merged until all CI checks have passed against code
+that has had the latest main merged in.
 
 Compatibility and versioning policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -277,6 +276,10 @@ When to make a minor release is at the discretion of the core developers. There 
 hard-and-fast rules, e.g., it is fine to make a minor release to make a single new
 feature available; equally, it is fine to make a minor release that includes a number of
 changes.
+
+When making a minor release, open an issue stating your intention so other developers
+know that a release is planned. At least a week's notice should be given for other
+developers to be aware of and possibly add to the contents of the release.
 
 Major releases obviously need to be given careful consideration, and should be done as
 infrequently as possible, as they will break existing code and/or affect data


### PR DESCRIPTION
This updates development practices to:

- Require that one review is required for all PRs. This is to prevent developers merging there own PRs, which I have been very guilty of in the past. Although it can be frustrating not getting a review, I think it's probably worth tipping the balance in favour of waiting and getting a review here.
- Require that new minor releases are announced for a week before happening. cc @jakirkham 