### PR TITLE
Emscripten

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -383,8 +383,6 @@ def run_setup(with_extensions):
         ext_modules = []
         cmdclass = {}
 
-    print(f"base compile args: {base_compile_args}")
-
     setup(
         ext_modules=ext_modules,
         cmdclass=cmdclass,

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,32 @@ from distutils.command.clean import clean
 from distutils.sysconfig import customize_compiler
 from glob import glob
 
-import cpuinfo
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 from setuptools import Extension, setup
 from setuptools.errors import CCompilerError, ExecError, PlatformError
 
-# determine CPU support for SSE2 and AVX2
-cpu_info = cpuinfo.get_cpu_info()
-flags = cpu_info.get('flags', [])
-machine = cpuinfo.platform.machine()
+if sys.version_info >= (3, 10):
+    import sysconfig
+else:
+    from distutils import sysconfig
 
+# We can't use sys.platform in a cross-compiling situation
+# as here it may be set to the host not target platform
+is_emscripten = (
+    sysconfig.get_config_var("SOABI")
+    and sysconfig.get_config_var("SOABI").find("emscripten") != -1
+)
+
+
+if not is_emscripten:
+    import cpuinfo
+    # determine CPU support for SSE2 and AVX2
+    cpu_info = cpuinfo.get_cpu_info()
+    flags = cpu_info.get('flags', [])
+    machine = cpuinfo.platform.machine()
+else:
+    flags = []
+    machine ="emscripten-wasm32"
 # only check for x86 features on x86_64 arch
 have_sse2 = False
 have_avx2 = False
@@ -42,7 +58,7 @@ elif os.name == 'posix' and machine == 'x86_64':
         base_compile_args.append('-mavx2')
 # On macOS, force libc++ in case the system tries to use `stdlibc++`.
 # The latter is often absent from modern macOS systems.
-if sys.platform == 'darwin':
+if sys.platform == 'darwin' and not is_emscripten:
     base_compile_args.append('-stdlib=libc++')
 
 
@@ -64,7 +80,7 @@ def blosc_extension():
     define_macros = []
 
     # ensure pthread is properly linked on POSIX systems
-    if os.name == 'posix':
+    if os.name == 'posix' and not is_emscripten:
         extra_compile_args.append('-pthread')
         extra_link_args.append('-pthread')
 
@@ -114,7 +130,7 @@ def blosc_extension():
         info('compiling Blosc extension without AVX2 support')
 
     # include assembly files
-    if cpuinfo.platform.machine() == 'x86_64':
+    if machine == 'x86_64':
         extra_objects = [
             S[:-1] + 'o' for S in glob("c-blosc/internal-complibs/zstd*/decompress/*amd64.S")
         ]
@@ -157,7 +173,7 @@ def zstd_extension():
     sources = ['numcodecs/zstd.pyx']
 
     # include assembly files
-    if cpuinfo.platform.machine() == 'x86_64':
+    if machine == 'x86_64':
         extra_objects = [
             S[:-1] + 'o' for S in glob("c-blosc/internal-complibs/zstd*/decompress/*amd64.S")
         ]
@@ -321,7 +337,6 @@ class ve_build_ext(build_ext):
 
     def run(self):
         try:
-            machine = cpuinfo.platform.machine()
             if machine in ('x86_64', 'aarch64'):
                 pattern = '*amd64.S' if machine == 'x86_64' else '*aarch64.S'
                 S_files = glob(f'c-blosc/internal-complibs/zstd*/decompress/{pattern}')
@@ -347,7 +362,7 @@ class Sclean(clean):
     # Clean up .o files created by .S files
 
     def run(self):
-        if cpuinfo.platform.machine() == 'x86_64':
+        if machine == 'x86_64':
             o_files = glob('c-blosc/internal-complibs/zstd*/decompress/*amd64.o')
             for f in o_files:
                 os.remove(f)
@@ -372,6 +387,8 @@ def run_setup(with_extensions):
     else:
         ext_modules = []
         cmdclass = {}
+
+    print(f"base compile args: {base_compile_args}")
 
     setup(
         ext_modules=ext_modules,

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,8 @@ if sys.version_info >= (3, 10):
 else:
     from distutils import sysconfig
 
-# We can't use sys.platform in a cross-compiling situation
-# as here it may be set to the host not target platform
-is_emscripten = (
-    sysconfig.get_config_var("SOABI")
-    and sysconfig.get_config_var("SOABI").find("emscripten") != -1
-)
-
+# sys.platform is not trustworthy in a cross-compiling environment
+is_emscripten = sysconfig.get_config_var("SOABI") and "emscripten" in sysconfig.get_config_var("SOABI")
 
 if not is_emscripten:
     import cpuinfo


### PR DESCRIPTION
These changes are needed to build the package with emscripten.
This PR disables / bypasses the usage of the `cpuinfo` package when building for emscripten-wasm32.
Furthermore I removed the threading argument from blosc when compiling for emscripten.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
