### PR TITLE
Unskip accidentally skipped tests

### DIFF
--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -202,7 +202,7 @@ def check_backwards_compatibility(codec_id, arrays, codecs, precision=None, pref
 
         for j, codec in enumerate(codecs):
             if codec is None:
-                pytest.skip("codec has been removed")
+                continue
 
             # setup a directory to hold encoded data
             codec_dir = os.path.join(fixture_dir, f'codec.{j:02d}')

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -245,20 +245,20 @@ def test_err_encode_object_buffer():
     check_err_encode_object_buffer(Blosc())
 
 
-def test_decompression_error_handling():
-    for codec in codecs:
-        _skip_null(codec)
-        with pytest.raises(RuntimeError):
-            codec.decode(bytearray())
-        with pytest.raises(RuntimeError):
-            codec.decode(bytearray(0))
+@pytest.mark.parametrize('codec', codecs)
+def test_decompression_error_handling(codec):
+    _skip_null(codec)
+    with pytest.raises(RuntimeError):
+        codec.decode(bytearray())
+    with pytest.raises(RuntimeError):
+        codec.decode(bytearray(0))
 
 
-def test_max_buffer_size():
-    for codec in codecs:
-        _skip_null(codec)
-        assert codec.max_buffer_size == 2**31 - 1
-        check_max_buffer_size(codec)
+@pytest.mark.parametrize('codec', codecs)
+def test_max_buffer_size(codec):
+    _skip_null(codec)
+    assert codec.max_buffer_size == 2**31 - 1
+    check_max_buffer_size(codec)
 
 
 def test_typesize_explicit():


### PR DESCRIPTION
When a `pytest.skip()` is executed it skips the entire running test, not just the current for loop. This means putting a `pytest.skip()` inside a for loop can accidentally skip tests. The fix here is to parametrize the tests instead of using for loops.