### PR TITLE
(fix): ensure no `typesize` in the `Blosc` config

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -38,7 +38,7 @@ Fixes
 * Add ``#ifndef`` guard around ``PyBytes_RESIZE``.
   By :user:`John Kirkham <jakirkham>`, :issue:`732`
 
-* Remove ``typesize`` from :func:`Blosc.get_config` output
+* Remove ``typesize`` from ``Blosc.get_config`` output
   By :user:`Ilan Gold <ilan-gold>`
 
 Maintenance

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -38,6 +38,9 @@ Fixes
 * Add ``#ifndef`` guard around ``PyBytes_RESIZE``.
   By :user:`John Kirkham <jakirkham>`, :issue:`732`
 
+* Remove ``typesize`` from :func:`Blosc.get_config` output
+  By :user:`Ilan Gold <ilan-gold>`
+
 Maintenance
 ~~~~~~~~~~~
 

--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -489,11 +489,11 @@ class Blosc(Codec):
         self.clevel = clevel
         self.shuffle = shuffle
         self.blocksize = blocksize
-        self.typesize = typesize
+        self._typesize = typesize
 
     def encode(self, buf):
         buf = ensure_contiguous_ndarray(buf, self.max_buffer_size)
-        return compress(buf, self._cname_bytes, self.clevel, self.shuffle, self.blocksize, self.typesize)
+        return compress(buf, self._cname_bytes, self.clevel, self.shuffle, self.blocksize, self._typesize)
 
     def decode(self, buf, out=None):
         buf = ensure_contiguous_ndarray(buf, self.max_buffer_size)

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -282,3 +282,9 @@ def test_typesize_less_than_1():
     arr = np.arange(100)
     with pytest.raises(ValueError, match=r"Cannot use typesize"):
         compressor.encode(arr.tobytes())
+
+
+def test_config_no_typesize():
+    codec = Blosc(shuffle=Blosc.SHUFFLE, typesize=5)
+    config = codec.get_config()
+    assert "typesize" not in config

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -278,7 +278,7 @@ def test_typesize_less_than_1():
         Blosc(shuffle=Blosc.SHUFFLE, typesize=0)
     compressor = Blosc(shuffle=Blosc.SHUFFLE)
     # not really something that should be done in practice, but good for testing.
-    compressor.typesize = 0
+    compressor._typesize = 0
     arr = np.arange(100)
     with pytest.raises(ValueError, match=r"Cannot use typesize"):
         compressor.encode(arr.tobytes())


### PR DESCRIPTION
Addressing https://github.com/zarr-developers/numcodecs/pull/713#issuecomment-2797357740, I think it should be really this easy, but not so familiar with this area of things.

cc @jbms @dstansby  

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
