### PR TITLE
Use `pytest.skipif` to properly report skipped CRC32C codec tests

### DIFF
--- a/numcodecs/tests/test_checksum32.py
+++ b/numcodecs/tests/test_checksum32.py
@@ -39,46 +39,51 @@ arrays = [
     np.random.randint(-(2**63), -(2**63) + 20, size=1000, dtype='i8').view('m8[m]'),
 ]
 
-codecs = [
+base_codecs = [
     CRC32(),
     CRC32(location="end"),
     Adler32(),
     Adler32(location="end"),
 ]
-if has_crc32c:
-    codecs.extend(
-        [
-            CRC32C(location="start"),
-            CRC32C(),
-        ]
-    )
 
 
-@pytest.mark.parametrize(("codec", "arr"), itertools.product(codecs, arrays))
+def get_all_codecs():
+    codecs = base_codecs.copy()
+    if has_crc32c:
+        codecs.extend(
+            [
+                CRC32C(location="start"),
+                CRC32C(),
+            ]
+        )
+    return codecs
+
+
+@pytest.mark.parametrize(("codec", "arr"), itertools.product(get_all_codecs(), arrays))
 def test_encode_decode(codec, arr):
     check_encode_decode(arr, codec)
 
 
-@pytest.mark.parametrize(("codec", "arr"), itertools.product(codecs, arrays))
+@pytest.mark.parametrize(("codec", "arr"), itertools.product(get_all_codecs(), arrays))
 def test_errors(codec, arr):
     enc = codec.encode(arr)
     with pytest.raises(RuntimeError):
         codec.decode(enc[:-1])
 
 
-@pytest.mark.parametrize("codec", codecs)
+@pytest.mark.parametrize("codec", get_all_codecs())
 def test_config(codec):
     check_config(codec)
 
 
-@pytest.mark.parametrize("codec", codecs)
+@pytest.mark.parametrize("codec", get_all_codecs())
 def test_err_input_too_small(codec):
     buf = b'000'  # 3 bytes are too little for a 32-bit checksum
     with pytest.raises(ValueError):
         codec.decode(buf)
 
 
-@pytest.mark.parametrize("codec", codecs)
+@pytest.mark.parametrize("codec", get_all_codecs())
 def test_err_encode_non_contiguous(codec):
     # non-contiguous memory
     arr = np.arange(1000, dtype='i4')[::2]
@@ -86,7 +91,7 @@ def test_err_encode_non_contiguous(codec):
         codec.encode(arr)
 
 
-@pytest.mark.parametrize("codec", codecs)
+@pytest.mark.parametrize("codec", get_all_codecs())
 def test_err_encode_list(codec):
     data = ['foo', 'bar', 'baz']
     with pytest.raises(TypeError):
@@ -98,39 +103,60 @@ def test_err_location():
         CRC32(location="foo")
     with pytest.raises(ValueError):
         Adler32(location="foo")
-    if has_crc32c:
-        with pytest.raises(ValueError):
-            CRC32C(location="foo")
+    if not has_crc32c:
+        pytest.skip("Needs `crc32c` installed")
+    with pytest.raises(ValueError):
+        CRC32C(location="foo")
 
 
-def test_repr():
-    check_repr("CRC32(location='start')")
-    check_repr("CRC32(location='end')")
-    check_repr("Adler32(location='start')")
-    check_repr("Adler32(location='end')")
-    if has_crc32c:
-        check_repr("CRC32C(location='start')")
-        check_repr("CRC32C(location='end')")
+@pytest.mark.parametrize(
+    "repr_str",
+    [
+        "CRC32(location='start')",
+        "CRC32(location='end')",
+        "Adler32(location='start')",
+        "Adler32(location='end')",
+        pytest.param(
+            "CRC32C(location='start')",
+            marks=pytest.mark.skipif(not has_crc32c, reason="Needs `crc32c` installed"),
+        ),
+        pytest.param(
+            "CRC32C(location='end')",
+            marks=pytest.mark.skipif(not has_crc32c, reason="Needs `crc32c` installed"),
+        ),
+    ],
+)
+def test_repr(repr_str):
+    check_repr(repr_str)
 
 
-def test_backwards_compatibility():
-    check_backwards_compatibility(CRC32.codec_id, arrays, [CRC32()])
-    check_backwards_compatibility(Adler32.codec_id, arrays, [Adler32()])
-    if has_crc32c:
-        check_backwards_compatibility(CRC32C.codec_id, arrays, [CRC32C()])
+@pytest.mark.parametrize(
+    ('codec_id', 'codec_instance'),
+    [
+        (CRC32.codec_id, CRC32()),
+        (Adler32.codec_id, Adler32()),
+    ],
+)
+def test_backwards_compatibility(codec_id, codec_instance):
+    check_backwards_compatibility(codec_id, arrays, [codec_instance])
 
 
-@pytest.mark.parametrize("codec", codecs)
+@pytest.mark.skipif(not has_crc32c, reason="Needs `crc32c` installed")
+def test_backwards_compatibility_crc32c():
+    check_backwards_compatibility(CRC32C.codec_id, arrays, [CRC32C()])
+
+
+@pytest.mark.parametrize("codec", get_all_codecs())
 def test_err_encode_object_buffer(codec):
     check_err_encode_object_buffer(codec)
 
 
-@pytest.mark.parametrize("codec", codecs)
+@pytest.mark.parametrize("codec", get_all_codecs())
 def test_err_decode_object_buffer(codec):
     check_err_decode_object_buffer(codec)
 
 
-@pytest.mark.parametrize("codec", codecs)
+@pytest.mark.parametrize("codec", get_all_codecs())
 def test_err_out_too_small(codec):
     arr = np.arange(10, dtype='i4')
     out = np.empty_like(arr)[:-1]
@@ -145,7 +171,7 @@ def test_crc32c_checksum():
     assert np.frombuffer(buf, dtype="<u4", offset=(len(buf) - 4))[0] == np.uint32(4218238699)
 
 
-@pytest.mark.parametrize("codec", codecs)
+@pytest.mark.parametrize("codec", get_all_codecs())
 def test_err_checksum(codec):
     arr = np.arange(0, 64, dtype="uint8")
     buf = bytearray(codec.encode(arr))


### PR DESCRIPTION
The tests `test_err_location`, `test_repr`, and `test_backwards_compatibility` were not reporting that they were skipped if the `crc32c` dependency wasn't available/installed, as they weren't marked with the appropriate markers. This PR skips these tests at the `pytest` level rather than using a `has_crc32c` check that defines the tests at collection. I've parametrized most of these tests. I had to split up the `test_backwards_compatibility` test into two, as `CRC32C()` wouldn't be defined if it were not installed (I don't think it makes sense to mock it just for one test).

Closes #640

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
