### PR TITLE
add numcodecs.zarr3.to_zarr3 method

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -11,7 +11,6 @@ Release notes
     Unreleased
     ----------
 
-
 .. _unreleased:
 
 Unreleased
@@ -19,6 +18,9 @@ Unreleased
 
 Enhancements
 ~~~~~~~~~~~~
+
+* implement ``to_zarr3`` in ``numcodecs.zarr3`` to enable conversion of a codec to its zarr3-compatible equivalent.
+  By :user:`Hannes Spitz <brokkoli71>`
 
 Improvements
 ~~~~~~~~~~~~
@@ -63,7 +65,7 @@ Enhancements
 Removals
 ~~~~~~~~
 
-The following ``blosc`` funcitons are removed, with no replacement.
+The following ``blosc`` functions are removed, with no replacement.
 This is because they were not intended to be public API.
 
 - ``numcodecs.blosc.init``

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -260,7 +260,7 @@ def test_delta_astype(store: StorePath):
             dtype=data.dtype,
             fill_value=0,
             filters=[
-                numcodecs.Delta(dtype="i8", astype="i2"),  # type: ignore[arg-type]
+                numcodecs.zarr3.Delta(dtype="i8", astype="i2"),  # type: ignore[arg-type]
             ],
         )
 

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -317,17 +317,25 @@ def test_cast_numcodecs_to_v3(store: Store, codec_v2, expected_v3_cls) -> None:
     assert result_v3.__class__ == expected_v3_cls
     assert result_v3.codec_config == codec_v2.get_config()
 
-    from zarr.core.array import CompressorsLike, FiltersLike, SerializerLike
-
-    codec_args: FiltersLike | SerializerLike | CompressorsLike
-
+    filters = "auto"
+    serializer = "auto"
+    compressors = "auto"
     if issubclass(expected_v3_cls, numcodecs.zarr3._NumcodecsArrayArrayCodec):
-        codec_args = {"filters": [result_v3]}
+        filters = [result_v3]
     elif issubclass(expected_v3_cls, numcodecs.zarr3._NumcodecsArrayBytesCodec):
-        codec_args = {"serializer": result_v3}
+        serializer = result_v3
     elif issubclass(expected_v3_cls, numcodecs.zarr3._NumcodecsBytesBytesCodec):
-        codec_args = {"compressors": [result_v3]}
+        compressors = [result_v3]
     else:
         raise TypeError(f"unsupported type: {expected_v3_cls}")
 
-    zarr.create_array(store, shape=(64,), chunks=(64,), dtype=np.bool, fill_value=0, **codec_args)
+    zarr.create_array(
+        store,
+        shape=(64,),
+        chunks=(64,),
+        dtype=np.bool,
+        fill_value=0,
+        filters=filters,
+        compressors=compressors,
+        serializer=serializer,
+    )

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -278,34 +278,48 @@ def test_to_dict():
     codec = numcodecs.zarr3.LZ4(level=5)
     assert codec.to_dict() == {"name": "numcodecs.lz4", "configuration": {"level": 5}}
 
-@pytest.mark.parametrize(("codec_v2", "expected_v3_cls"),[
-    (numcodecs.BZ2(), numcodecs.zarr3.BZ2),
-    (numcodecs.CRC32(), numcodecs.zarr3.CRC32),
-    (numcodecs.CRC32C(), numcodecs.zarr3.CRC32C),
-    (numcodecs.LZ4(), numcodecs.zarr3.LZ4),
-    (numcodecs.LZMA(), numcodecs.zarr3.LZMA),
-    (numcodecs.ZFPY(), numcodecs.zarr3.ZFPY),
-    (numcodecs.Adler32(), numcodecs.zarr3.Adler32),
-    (numcodecs.AsType(encode_dtype=np.float64,decode_dtype=np.float32), numcodecs.zarr3.AsType),
-    (numcodecs.BitRound(keepbits=10), numcodecs.zarr3.BitRound),
-    (numcodecs.Blosc(), numcodecs.zarr3.Blosc),
-    (numcodecs.Delta(dtype=np.float64), numcodecs.zarr3.Delta),
-    (numcodecs.FixedScaleOffset(offset=1000, scale=10, dtype='f8', astype='u1'), numcodecs.zarr3.FixedScaleOffset),
-    (numcodecs.Fletcher32(), numcodecs.zarr3.Fletcher32),
-    (numcodecs.GZip(), numcodecs.zarr3.GZip),
-    (numcodecs.JenkinsLookup3(), numcodecs.zarr3.JenkinsLookup3),
-    (numcodecs.PCodec(), numcodecs.zarr3.PCodec),
-    (numcodecs.PackBits(), numcodecs.zarr3.PackBits),
-    (numcodecs.Quantize(digits=1, dtype='f8'), numcodecs.zarr3.Quantize),
-    (numcodecs.Shuffle(), numcodecs.zarr3.Shuffle),
-    (numcodecs.Zlib(), numcodecs.zarr3.Zlib),
-    (numcodecs.Zstd(), numcodecs.zarr3.Zstd),
-])
+
+@pytest.mark.parametrize(
+    ("codec_v2", "expected_v3_cls"),
+    [
+        (numcodecs.BZ2(), numcodecs.zarr3.BZ2),
+        (numcodecs.CRC32(), numcodecs.zarr3.CRC32),
+        (numcodecs.CRC32C(), numcodecs.zarr3.CRC32C),
+        (numcodecs.LZ4(), numcodecs.zarr3.LZ4),
+        (numcodecs.LZMA(), numcodecs.zarr3.LZMA),
+        (numcodecs.ZFPY(), numcodecs.zarr3.ZFPY),
+        (numcodecs.Adler32(), numcodecs.zarr3.Adler32),
+        (
+            numcodecs.AsType(encode_dtype=np.float64, decode_dtype=np.float32),
+            numcodecs.zarr3.AsType,
+        ),
+        (numcodecs.BitRound(keepbits=10), numcodecs.zarr3.BitRound),
+        (numcodecs.Blosc(), numcodecs.zarr3.Blosc),
+        (numcodecs.Delta(dtype=np.float64), numcodecs.zarr3.Delta),
+        (
+            numcodecs.FixedScaleOffset(offset=1000, scale=10, dtype='f8', astype='u1'),
+            numcodecs.zarr3.FixedScaleOffset,
+        ),
+        (numcodecs.Fletcher32(), numcodecs.zarr3.Fletcher32),
+        (numcodecs.GZip(), numcodecs.zarr3.GZip),
+        (numcodecs.JenkinsLookup3(), numcodecs.zarr3.JenkinsLookup3),
+        (numcodecs.PCodec(), numcodecs.zarr3.PCodec),
+        (numcodecs.PackBits(), numcodecs.zarr3.PackBits),
+        (numcodecs.Quantize(digits=1, dtype='f8'), numcodecs.zarr3.Quantize),
+        (numcodecs.Shuffle(), numcodecs.zarr3.Shuffle),
+        (numcodecs.Zlib(), numcodecs.zarr3.Zlib),
+        (numcodecs.Zstd(), numcodecs.zarr3.Zstd),
+    ],
+)
 def test_cast_numcodecs_to_v3(store: Store, codec_v2, expected_v3_cls) -> None:
     result_v3 = numcodecs.zarr3.to_zarr3(codec_v2)
 
     assert result_v3.__class__ == expected_v3_cls
     assert result_v3.codec_config == codec_v2.get_config()
+
+    from zarr.abc.codec import Codec
+
+    codec_args: dict[str, Codec]
 
     if issubclass(expected_v3_cls, numcodecs.zarr3._NumcodecsArrayArrayCodec):
         codec_args = {"filters": [result_v3]}
@@ -315,11 +329,5 @@ def test_cast_numcodecs_to_v3(store: Store, codec_v2, expected_v3_cls) -> None:
         codec_args = {"compressors": [result_v3]}
     else:
         raise TypeError(f"unsupported type: {expected_v3_cls}")
-    zarr.create_array(
-        store,
-        shape=(64,),
-        chunks=(64,),
-        dtype=np.bool,
-        fill_value=0,
-        **codec_args
-    )
+
+    zarr.create_array(store, shape=(64,), chunks=(64,), dtype=np.bool, fill_value=0, **codec_args)

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -317,9 +317,9 @@ def test_cast_numcodecs_to_v3(store: Store, codec_v2, expected_v3_cls) -> None:
     assert result_v3.__class__ == expected_v3_cls
     assert result_v3.codec_config == codec_v2.get_config()
 
-    from zarr.abc.codec import Codec
+    from zarr.core.array import CompressorsLike, FiltersLike, SerializerLike
 
-    codec_args: dict[str, Codec]
+    codec_args: FiltersLike | SerializerLike | CompressorsLike
 
     if issubclass(expected_v3_cls, numcodecs.zarr3._NumcodecsArrayArrayCodec):
         codec_args = {"filters": [result_v3]}

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -399,3 +399,18 @@ __all__ = [
     "Zlib",
     "Zstd",
 ]
+
+def to_zarr3(codec: numcodecs.abc.Codec) -> _NumcodecsBytesBytesCodec | _NumcodecsArrayBytesCodec | _NumcodecsArrayArrayCodec:
+    """Convert a numcodecs codec to its zarr3-compatible equivalent."""
+    codec_name = codec.__class__.__name__
+    zarr3_module = numcodecs.zarr3
+
+    if not hasattr(zarr3_module, codec_name):
+        raise ValueError(f"No Zarr3 wrapper found for codec: {codec_name}")
+
+    zarr3_codec_class = getattr(zarr3_module, codec_name)
+
+    config = codec.get_config()
+    config.pop("id", None)
+
+    return zarr3_codec_class(**config)

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -400,7 +400,10 @@ __all__ = [
     "Zstd",
 ]
 
-def to_zarr3(codec: numcodecs.abc.Codec) -> _NumcodecsBytesBytesCodec | _NumcodecsArrayBytesCodec | _NumcodecsArrayArrayCodec:
+
+def to_zarr3(
+    codec: numcodecs.abc.Codec,
+) -> _NumcodecsBytesBytesCodec | _NumcodecsArrayBytesCodec | _NumcodecsArrayArrayCodec:
     """Convert a numcodecs codec to its zarr3-compatible equivalent."""
     codec_name = codec.__class__.__name__
     zarr3_module = numcodecs.zarr3


### PR DESCRIPTION
- implements `to_zarr3` function in `numcodecs.zarr3` for https://github.com/zarr-developers/zarr-python/issues/2964

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
