### PR TITLE
Make all codecs pickleable

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -25,6 +25,8 @@ Improvements
 
 * In ``vlen``, define and use ``const`` ``HEADER_LENGTH``.
   By :user:`John Kirkham <jakirkham>`, :issue:`723`
+* All codecs are now pickleable.
+  By :user:`Tom Nicholas <TomNicholas>`, :issue:`744`
 
 Fixes
 ~~~~~

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pickle
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -277,3 +278,31 @@ def test_repr():
 def test_to_dict():
     codec = numcodecs.zarr3.LZ4(level=5)
     assert codec.to_dict() == {"name": "numcodecs.lz4", "configuration": {"level": 5}}
+
+
+@pytest.mark.parametrize(
+    "codec_cls",
+    [
+        numcodecs.zarr3.Blosc,
+        numcodecs.zarr3.LZ4,
+        numcodecs.zarr3.Zstd,
+        numcodecs.zarr3.Zlib,
+        numcodecs.zarr3.GZip,
+        numcodecs.zarr3.BZ2,
+        numcodecs.zarr3.LZMA,
+        numcodecs.zarr3.Shuffle,
+    ],
+)
+def test_codecs_pickleable(codec_cls):
+    codec = codec_cls()
+
+    expected = codec
+
+    p = pickle.dumps(codec)
+    actual = pickle.loads(p)
+    assert actual == expected
+
+    print(codec)
+    print(codec.codec_name)
+    print(codec.__doc__)
+    #assert False

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -298,6 +298,7 @@ def test_to_dict():
         numcodecs.zarr3.FixedScaleOffset,
         numcodecs.zarr3.Quantize,
         numcodecs.zarr3.PackBits,
+        numcodecs.zarr3.AsType,
     ],
 )
 def test_codecs_pickleable(codec_cls):

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -299,6 +299,11 @@ def test_to_dict():
         numcodecs.zarr3.Quantize,
         numcodecs.zarr3.PackBits,
         numcodecs.zarr3.AsType,
+        numcodecs.zarr3.CRC32,
+        numcodecs.zarr3.CRC32C,
+        numcodecs.zarr3.Adler32,
+        numcodecs.zarr3.Fletcher32,
+        numcodecs.zarr3.JenkinsLookup3,
     ],
 )
 def test_codecs_pickleable(codec_cls):

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pickle
 from typing import TYPE_CHECKING
 
+import numcodecs.bitround
 import numpy as np
 import pytest
 
@@ -291,6 +292,7 @@ def test_to_dict():
         numcodecs.zarr3.BZ2,
         numcodecs.zarr3.LZMA,
         numcodecs.zarr3.Shuffle,
+        numcodecs.zarr3.BitRound,
     ],
 )
 def test_codecs_pickleable(codec_cls):
@@ -301,8 +303,3 @@ def test_codecs_pickleable(codec_cls):
     p = pickle.dumps(codec)
     actual = pickle.loads(p)
     assert actual == expected
-
-    print(codec)
-    print(codec.codec_name)
-    print(codec.__doc__)
-    #assert False

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -297,6 +297,7 @@ def test_to_dict():
         numcodecs.zarr3.Delta,
         numcodecs.zarr3.FixedScaleOffset,
         numcodecs.zarr3.Quantize,
+        numcodecs.zarr3.PackBits,
     ],
 )
 def test_codecs_pickleable(codec_cls):

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -304,6 +304,8 @@ def test_to_dict():
         numcodecs.zarr3.Adler32,
         numcodecs.zarr3.Fletcher32,
         numcodecs.zarr3.JenkinsLookup3,
+        numcodecs.zarr3.PCodec,
+        numcodecs.zarr3.ZFPY,
     ],
 )
 def test_codecs_pickleable(codec_cls):

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -281,6 +281,7 @@ def test_to_dict():
     assert codec.to_dict() == {"name": "numcodecs.lz4", "configuration": {"level": 5}}
 
 
+# TODO replace this explicit list of parametrizations by somehow importing all from numcodecs.zarr3
 @pytest.mark.parametrize(
     "codec_cls",
     [
@@ -295,6 +296,7 @@ def test_to_dict():
         numcodecs.zarr3.BitRound,
         numcodecs.zarr3.Delta,
         numcodecs.zarr3.FixedScaleOffset,
+        numcodecs.zarr3.Quantize,
     ],
 )
 def test_codecs_pickleable(codec_cls):

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -281,7 +281,6 @@ def test_to_dict():
     assert codec.to_dict() == {"name": "numcodecs.lz4", "configuration": {"level": 5}}
 
 
-# TODO replace this explicit list of parametrizations by somehow importing all from numcodecs.zarr3
 @pytest.mark.parametrize(
     "codec_cls",
     [

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -294,6 +294,7 @@ def test_to_dict():
         numcodecs.zarr3.Shuffle,
         numcodecs.zarr3.BitRound,
         numcodecs.zarr3.Delta,
+        numcodecs.zarr3.FixedScaleOffset,
     ],
 )
 def test_codecs_pickleable(codec_cls):

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -263,7 +263,7 @@ def test_delta_astype(store: StorePath):
             dtype=data.dtype,
             fill_value=0,
             filters=[
-                numcodecs.zarr3.Delta(dtype="i8", astype="i2"),  # type: ignore[arg-type]
+                numcodecs.zarr3.Delta(dtype="i8", astype="i2"),
             ],
         )
 

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -293,6 +293,7 @@ def test_to_dict():
         numcodecs.zarr3.LZMA,
         numcodecs.zarr3.Shuffle,
         numcodecs.zarr3.BitRound,
+        numcodecs.zarr3.Delta,
     ],
 )
 def test_codecs_pickleable(codec_cls):

--- a/numcodecs/tests/test_zarr3.py
+++ b/numcodecs/tests/test_zarr3.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import pickle
 from typing import TYPE_CHECKING
 
-import numcodecs.bitround
 import numpy as np
 import pytest
+
+import numcodecs.bitround
 
 if TYPE_CHECKING:  # pragma: no cover
     import zarr

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -207,20 +207,6 @@ def _add_docstring_wrapper(ref_class_name: str) -> partial:
     return partial(_add_docstring, ref_class_name=ref_class_name)
 
 
-def _make_array_array_codec(codec_name: str, cls_name: str) -> type[_NumcodecsArrayArrayCodec]:
-    # rename for class scope
-    _codec_name = CODEC_PREFIX + codec_name
-
-    class _Codec(_NumcodecsArrayArrayCodec):
-        codec_name = _codec_name
-
-        def __init__(self, **codec_config: JSON) -> None:
-            super().__init__(**codec_config)
-
-    _Codec.__name__ = cls_name
-    return _Codec
-
-
 def _make_array_bytes_codec(codec_name: str, cls_name: str) -> type[_NumcodecsArrayBytesCodec]:
     # rename for class scope
     _codec_name = CODEC_PREFIX + codec_name
@@ -308,9 +294,8 @@ class Delta(_NumcodecsArrayArrayCodec):
         return chunk_spec
 
 
-BitRound = _add_docstring(
-    _make_array_array_codec("bitround", "BitRound"), "numcodecs.bitround.BitRound"
-)
+class BitRound(_NumcodecsArrayArrayCodec, codec_name="bitround"):
+    pass
 
 
 @_add_docstring_wrapper("numcodecs.fixedscaleoffset.FixedScaleOffset")

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -267,17 +267,11 @@ class LZMA(_NumcodecsBytesBytesCodec, codec_name="lzma"):
     pass
 
 
-@_add_docstring_wrapper("numcodecs.shuffle.Shuffle")
-class Shuffle(_NumcodecsBytesBytesCodec):
-    codec_name = f"{CODEC_PREFIX}shuffle"
-
-    def __init__(self, **codec_config: JSON) -> None:
-        super().__init__(**codec_config)
-
+class Shuffle(_NumcodecsBytesBytesCodec, codec_name="shuffle"):
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> Shuffle:
-        if self.codec_config.get("elementsize", None) is None:
-            return Shuffle(**{**self.codec_config, "elementsize": array_spec.dtype.itemsize})
-        return self  # pragma: no cover
+         if self.codec_config.get("elementsize", None) is None:
+             return Shuffle(**{**self.codec_config, "elementsize": array_spec.dtype.itemsize})
+         return self  # pragma: no cover
 
 
 # array-to-array codecs ("filters")

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -321,13 +321,7 @@ class PackBits(_NumcodecsArrayArrayCodec, codec_name="packbits"):
             raise ValueError(f"Packbits filter requires bool dtype. Got {dtype}.")
 
 
-@_add_docstring_wrapper("numcodecs.astype.AsType")
-class AsType(_NumcodecsArrayArrayCodec):
-    codec_name = f"{CODEC_PREFIX}astype"
-
-    def __init__(self, **codec_config: JSON) -> None:
-        super().__init__(**codec_config)
-
+class AsType(_NumcodecsArrayArrayCodec, codec_name="astype"):
     def resolve_metadata(self, chunk_spec: ArraySpec) -> ArraySpec:
         return replace(chunk_spec, dtype=np.dtype(self.codec_config["encode_dtype"]))  # type: ignore[arg-type]
 

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -298,10 +298,7 @@ class FixedScaleOffset(_NumcodecsArrayArrayCodec, codec_name="fixedscaleoffset")
         return self
 
 
-@_add_docstring_wrapper("numcodecs.quantize.Quantize")
-class Quantize(_NumcodecsArrayArrayCodec):
-    codec_name = f"{CODEC_PREFIX}quantize"
-
+class Quantize(_NumcodecsArrayArrayCodec, codec_name="quantize"):
     def __init__(self, **codec_config: JSON) -> None:
         super().__init__(**codec_config)
 

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -308,13 +308,7 @@ class Quantize(_NumcodecsArrayArrayCodec, codec_name="quantize"):
         return self
 
 
-@_add_docstring_wrapper("numcodecs.packbits.PackBits")
-class PackBits(_NumcodecsArrayArrayCodec):
-    codec_name = f"{CODEC_PREFIX}packbits"
-
-    def __init__(self, **codec_config: JSON) -> None:
-        super().__init__(**codec_config)
-
+class PackBits(_NumcodecsArrayArrayCodec, codec_name="packbits"):
     def resolve_metadata(self, chunk_spec: ArraySpec) -> ArraySpec:
         return replace(
             chunk_spec,

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -275,13 +275,7 @@ class Shuffle(_NumcodecsBytesBytesCodec, codec_name="shuffle"):
 
 
 # array-to-array codecs ("filters")
-@_add_docstring_wrapper("numcodecs.delta.Delta")
-class Delta(_NumcodecsArrayArrayCodec):
-    codec_name = f"{CODEC_PREFIX}delta"
-
-    def __init__(self, **codec_config: dict[str, JSON]) -> None:
-        super().__init__(**codec_config)
-
+class Delta(_NumcodecsArrayArrayCodec, codec_name="delta"):
     def resolve_metadata(self, chunk_spec: ArraySpec) -> ArraySpec:
         if astype := self.codec_config.get("astype"):
             return replace(chunk_spec, dtype=np.dtype(astype))  # type: ignore[call-overload]

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -84,8 +84,10 @@ class _NumcodecsCodec(Metadata):
         """To be used only when creating the actual public-facing codec class."""
         super().__init_subclass__(**kwargs)
         if codec_name is not None:
-            cls_name = f"{CODEC_PREFIX}{codec_name}.{cls.__name__}"
-            cls.codec_name = f"{CODEC_PREFIX}{codec_name}"
+            namespace = codec_name
+
+            cls_name = f"{CODEC_PREFIX}{namespace}.{cls.__name__}"
+            cls.codec_name = f"{CODEC_PREFIX}{namespace}"
             cls.__doc__ = f"""
             See :class:`{cls_name}` for more details and parameters.
             """
@@ -332,15 +334,30 @@ class AsType(_NumcodecsArrayArrayCodec, codec_name="astype"):
 
 
 # bytes-to-bytes checksum codecs
-CRC32 = _add_docstring(_make_checksum_codec("crc32", "CRC32"), "numcodecs.checksum32.CRC32")
-CRC32C = _add_docstring(_make_checksum_codec("crc32c", "CRC32C"), "numcodecs.checksum32.CRC32C")
-Adler32 = _add_docstring(_make_checksum_codec("adler32", "Adler32"), "numcodecs.checksum32.Adler32")
-Fletcher32 = _add_docstring(
-    _make_checksum_codec("fletcher32", "Fletcher32"), "numcodecs.fletcher32.Fletcher32"
-)
-JenkinsLookup3 = _add_docstring(
-    _make_checksum_codec("jenkins_lookup3", "JenkinsLookup3"), "numcodecs.checksum32.JenkinsLookup3"
-)
+class _NumcodecsChecksumCodec(_NumcodecsBytesBytesCodec):
+    def compute_encoded_size(self, input_byte_length: int, chunk_spec: ArraySpec) -> int:
+        return input_byte_length + 4  # pragma: no cover
+
+
+class CRC32(_NumcodecsChecksumCodec, codec_name="crc32"):
+    pass
+
+
+class CRC32C(_NumcodecsChecksumCodec, codec_name="crc32c"):
+    pass
+
+
+class Adler32(_NumcodecsChecksumCodec, codec_name="adler32"):
+    pass
+
+
+class Fletcher32(_NumcodecsChecksumCodec, codec_name="fletcher32"):
+    pass
+
+
+class JenkinsLookup3(_NumcodecsChecksumCodec, codec_name="jenkins_lookup3"):
+    pass
+
 
 # array-to-bytes codecs
 PCodec = _add_docstring(_make_array_bytes_codec("pcodec", "PCodec"), "numcodecs.pcodec.PCodec")

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -257,7 +257,16 @@ def _make_checksum_codec(codec_name: str, cls_name: str) -> type[_NumcodecsBytes
 Blosc = _add_docstring(_make_bytes_bytes_codec("blosc", "Blosc"), "numcodecs.blosc.Blosc")
 LZ4 = _add_docstring(_make_bytes_bytes_codec("lz4", "LZ4"), "numcodecs.lz4.LZ4")
 Zstd = _add_docstring(_make_bytes_bytes_codec("zstd", "Zstd"), "numcodecs.zstd.Zstd")
-Zlib = _add_docstring(_make_bytes_bytes_codec("zlib", "Zlib"), "numcodecs.zlib.Zlib")
+
+
+#Zlib = _add_docstring(_make_bytes_bytes_codec("zlib", "Zlib"), "numcodecs.zlib.Zlib")
+class Zlib(_NumcodecsBytesBytesCodec):
+    codec_name = CODEC_PREFIX + "zlib"
+
+    def __init__(self, **codec_config: JSON) -> None:
+        super().__init__(**codec_config)
+
+
 GZip = _add_docstring(_make_bytes_bytes_codec("gzip", "GZip"), "numcodecs.gzip.GZip")
 BZ2 = _add_docstring(_make_bytes_bytes_codec("bz2", "BZ2"), "numcodecs.bz2.BZ2")
 LZMA = _add_docstring(_make_bytes_bytes_codec("lzma", "LZMA"), "numcodecs.lzma.LZMA")

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -360,8 +360,13 @@ class JenkinsLookup3(_NumcodecsChecksumCodec, codec_name="jenkins_lookup3"):
 
 
 # array-to-bytes codecs
-PCodec = _add_docstring(_make_array_bytes_codec("pcodec", "PCodec"), "numcodecs.pcodec.PCodec")
-ZFPY = _add_docstring(_make_array_bytes_codec("zfpy", "ZFPY"), "numcodecs.zfpy.ZFPY")
+class PCodec(_NumcodecsArrayBytesCodec, codec_name="pcodec"):
+    pass
+
+
+class ZFPY(_NumcodecsArrayBytesCodec, codec_name="zfpy"):
+    pass
+
 
 __all__ = [
     "BZ2",

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -80,11 +80,11 @@ class _NumcodecsCodec(Metadata):
     codec_name: str
     codec_config: dict[str, JSON]
 
-    def __init_subclass__(cls, *, namespace: str | None = None, codec_name: str | None = None, **kwargs):
+    def __init_subclass__(cls, *, codec_name: str | None = None, **kwargs):
         """To be used only when creating the actual public-facing codec class."""
         super().__init_subclass__(**kwargs)
-        if namespace is not None and codec_name is not None:
-            cls_name = f"{CODEC_PREFIX}{namespace}.{codec_name}"
+        if codec_name is not None:
+            cls_name = f"{CODEC_PREFIX}{codec_name}.{cls.__name__}"
             cls.codec_name = f"{CODEC_PREFIX}{codec_name}"
             cls.__doc__ = f"""
             See :class:`{cls_name}` for more details and parameters.
@@ -253,31 +253,31 @@ def _make_checksum_codec(codec_name: str, cls_name: str) -> type[_NumcodecsBytes
 
 
 # bytes-to-bytes codecs
-class Blosc(_NumcodecsBytesBytesCodec, namespace="blosc", codec_name="Blosc"):
+class Blosc(_NumcodecsBytesBytesCodec, codec_name="blosc"):
     pass
 
 
-class LZ4(_NumcodecsBytesBytesCodec, namespace="lz4", codec_name="LZ4"):
+class LZ4(_NumcodecsBytesBytesCodec, codec_name="lz4"):
     pass
 
 
-class Zstd(_NumcodecsBytesBytesCodec, namespace="zstd", codec_name="Zstd"):
+class Zstd(_NumcodecsBytesBytesCodec, codec_name="zstd"):
     pass
 
 
-class Zlib(_NumcodecsBytesBytesCodec, namespace="zlib", codec_name="Zlib"):
+class Zlib(_NumcodecsBytesBytesCodec, codec_name="zlib"):
     pass
 
 
-class GZip(_NumcodecsBytesBytesCodec, namespace="gzip", codec_name="GZip"):
+class GZip(_NumcodecsBytesBytesCodec, codec_name="gzip"):
     pass
 
 
-class BZ2(_NumcodecsBytesBytesCodec, namespace="bz2", codec_name="BZ2"):
+class BZ2(_NumcodecsBytesBytesCodec, codec_name="bz2"):
     pass
 
 
-class LZMA(_NumcodecsBytesBytesCodec, namespace="lzma",codec_name="LZMA"):
+class LZMA(_NumcodecsBytesBytesCodec, codec_name="lzma"):
     pass
 
 

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -75,11 +75,6 @@ def _parse_codec_configuration(data: dict[str, JSON]) -> dict[str, JSON]:
     return {"id": id, **parsed_configuration}
 
 
-def snake_case(codec_name: str) -> str:
-    # TODO the Jenkins codec is a special case because it inserts an _
-    return codec_name.lower()
-
-
 @dataclass(frozen=True)
 class _NumcodecsCodec(Metadata):
     codec_name: str

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -286,13 +286,7 @@ class BitRound(_NumcodecsArrayArrayCodec, codec_name="bitround"):
     pass
 
 
-@_add_docstring_wrapper("numcodecs.fixedscaleoffset.FixedScaleOffset")
-class FixedScaleOffset(_NumcodecsArrayArrayCodec):
-    codec_name = f"{CODEC_PREFIX}fixedscaleoffset"
-
-    def __init__(self, **codec_config: JSON) -> None:
-        super().__init__(**codec_config)
-
+class FixedScaleOffset(_NumcodecsArrayArrayCodec, codec_name="fixedscaleoffset"):
     def resolve_metadata(self, chunk_spec: ArraySpec) -> ArraySpec:
         if astype := self.codec_config.get("astype"):
             return replace(chunk_spec, dtype=np.dtype(astype))  # type: ignore[call-overload]

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -193,53 +193,6 @@ class _NumcodecsArrayBytesCodec(_NumcodecsCodec, ArrayBytesCodec):
         return chunk_spec.prototype.buffer.from_bytes(out)
 
 
-T = TypeVar("T", bound=_NumcodecsCodec)
-
-
-def _add_docstring(cls: type[T], ref_class_name: str) -> type[T]:
-    cls.__doc__ = textwrap.dedent(
-        f"""
-        See :class:`{ref_class_name}` for more details and parameters.
-        """
-    )
-    return cls
-
-
-def _add_docstring_wrapper(ref_class_name: str) -> partial:
-    return partial(_add_docstring, ref_class_name=ref_class_name)
-
-
-def _make_array_bytes_codec(codec_name: str, cls_name: str) -> type[_NumcodecsArrayBytesCodec]:
-    # rename for class scope
-    _codec_name = CODEC_PREFIX + codec_name
-
-    class _Codec(_NumcodecsArrayBytesCodec):
-        codec_name = _codec_name
-
-        def __init__(self, **codec_config: JSON) -> None:
-            super().__init__(**codec_config)
-
-    _Codec.__name__ = cls_name
-    return _Codec
-
-
-def _make_checksum_codec(codec_name: str, cls_name: str) -> type[_NumcodecsBytesBytesCodec]:
-    # rename for class scope
-    _codec_name = CODEC_PREFIX + codec_name
-
-    class _ChecksumCodec(_NumcodecsBytesBytesCodec):
-        codec_name = _codec_name
-
-        def __init__(self, **codec_config: JSON) -> None:
-            super().__init__(**codec_config)
-
-        def compute_encoded_size(self, input_byte_length: int, chunk_spec: ArraySpec) -> int:
-            return input_byte_length + 4  # pragma: no cover
-
-    _ChecksumCodec.__name__ = cls_name
-    return _ChecksumCodec
-
-
 # bytes-to-bytes codecs
 class Blosc(_NumcodecsBytesBytesCodec, codec_name="blosc"):
     pass

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -74,10 +74,23 @@ def _parse_codec_configuration(data: dict[str, JSON]) -> dict[str, JSON]:
     return {"id": id, **parsed_configuration}
 
 
+def snake_case(codec_name: str) -> str:
+    # TODO the Jenkins codec is a special case because it inserts an _
+    return codec_name.lower()
+
+
 @dataclass(frozen=True)
 class _NumcodecsCodec(Metadata):
     codec_name: str
     codec_config: dict[str, JSON]
+
+    def __init_subclass__(cls, *, codec_name: str | None = None, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if codec_name is not None:
+            cls.codec_name = CODEC_PREFIX + codec_name
+            cls.__doc__ = f"""
+            See :class:`{snake_case(cls.codec_name)}.{codec_name}` for more details and parameters.
+            """
 
     def __init__(self, **codec_config: JSON) -> None:
         if not self.codec_name:
@@ -260,11 +273,8 @@ Zstd = _add_docstring(_make_bytes_bytes_codec("zstd", "Zstd"), "numcodecs.zstd.Z
 
 
 #Zlib = _add_docstring(_make_bytes_bytes_codec("zlib", "Zlib"), "numcodecs.zlib.Zlib")
-class Zlib(_NumcodecsBytesBytesCodec):
-    codec_name = CODEC_PREFIX + "zlib"
-
-    def __init__(self, **codec_config: JSON) -> None:
-        super().__init__(**codec_config)
+class Zlib(_NumcodecsBytesBytesCodec, codec_name="Zlib"):
+    pass
 
 
 GZip = _add_docstring(_make_bytes_bytes_codec("gzip", "GZip"), "numcodecs.gzip.GZip")

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -223,9 +223,9 @@ class LZMA(_NumcodecsBytesBytesCodec, codec_name="lzma"):
 
 class Shuffle(_NumcodecsBytesBytesCodec, codec_name="shuffle"):
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> Shuffle:
-         if self.codec_config.get("elementsize", None) is None:
-             return Shuffle(**{**self.codec_config, "elementsize": array_spec.dtype.itemsize})
-         return self  # pragma: no cover
+        if self.codec_config.get("elementsize", None) is None:
+            return Shuffle(**{**self.codec_config, "elementsize": array_spec.dtype.itemsize})
+        return self  # pragma: no cover
 
 
 # array-to-array codecs ("filters")

--- a/numcodecs/zarr3.py
+++ b/numcodecs/zarr3.py
@@ -28,10 +28,9 @@ from __future__ import annotations
 import asyncio
 import math
 from dataclasses import dataclass, replace
-from functools import cached_property, partial
-from typing import Any, Self, TypeVar
+from functools import cached_property
+from typing import Any, Self
 from warnings import warn
-import textwrap
 
 import numpy as np
 


### PR DESCRIPTION
Attempt to fix #744, using the `__init_subclass__` approach suggested by @d-v-b.

I think this approach seems promising, but currently tests fail, and I don't know why. I get errors like

```python
    def get_codec(config):
        """Obtain a codec for the given configuration.
    
        Parameters
        ----------
        config : dict-like
            Configuration object.
    
        Returns
        -------
        codec : Codec
    
        Examples
        --------
    
        >>> import numcodecs as codecs
        >>> codec = codecs.get_codec(dict(id='zlib', level=1))
        >>> codec
        Zlib(level=1)
    
        """
        config = dict(config)
        codec_id = config.pop('id', None)
        cls = codec_registry.get(codec_id)
        if cls is None and codec_id in entries:
            logger.debug("Auto loading codec '%s' from entrypoint", codec_id)
            cls = entries[codec_id].load()
            register_codec(cls, codec_id=codec_id)
        if cls:
            return cls.from_config(config)
>       raise UnknownCodecError(f"{codec_id!r}")
E       numcodecs.errors.UnknownCodecError: codec not available: ''Blosc''
```

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [x] Changes documented in docs/release.rst
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
