### PR TITLE
ensure_bytes on buf for pcodec decode

### DIFF
--- a/numcodecs/pcodec.py
+++ b/numcodecs/pcodec.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from numcodecs.abc import Codec
-from numcodecs.compat import ensure_contiguous_ndarray
+from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
 from pcodec import ChunkConfig, DeltaSpec, ModeSpec, PagingSpec, standalone
 
 DEFAULT_MAX_PAGE_N = 262144
@@ -110,6 +110,7 @@ class PCodec(Codec):
         return standalone.simple_compress(buf, config)
 
     def decode(self, buf, out=None):
+        buf = ensure_bytes(buf)
         if out is not None:
             out = ensure_contiguous_ndarray(out)
             standalone.simple_decompress_into(buf, out)

--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -150,16 +150,6 @@ def check_encode_decode_array(arr, codec):
     assert_array_items_equal(arr, dec)
 
 
-def check_encode_decode_array_to_bytes(arr, codec):
-    enc = codec.encode(arr)
-    dec = codec.decode(enc)
-    assert_array_items_equal(arr, dec)
-
-    out = np.empty_like(arr)
-    codec.decode(enc, out=out)
-    assert_array_items_equal(arr, out)
-
-
 def check_config(codec):
     config = codec.get_config()
     # round-trip through JSON to check serialization

--- a/numcodecs/tests/test_pcodec.py
+++ b/numcodecs/tests/test_pcodec.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma: no cover
 from numcodecs.tests.common import (
     check_backwards_compatibility,
     check_config,
-    check_encode_decode_array_to_bytes,
+    check_encode_decode_array,
     check_err_decode_object_buffer,
     check_err_encode_object_buffer,
     check_repr,
@@ -49,7 +49,7 @@ arrays = [
 @pytest.mark.parametrize("arr", arrays)
 @pytest.mark.parametrize("codec", codecs)
 def test_encode_decode(arr, codec):
-    check_encode_decode_array_to_bytes(arr, codec)
+    check_encode_decode_array(arr, codec)
 
 
 def test_config():
@@ -61,13 +61,13 @@ def test_config():
 def test_invalid_config_error(param):
     codec = PCodec(**{param: "bogus"})
     with pytest.raises(ValueError):
-        check_encode_decode_array_to_bytes(arrays[0], codec)
+        check_encode_decode_array(arrays[0], codec)
 
 
 def test_invalid_delta_encoding_combo():
     codec = PCodec(delta_encoding_order=2, delta_spec="none")
     with pytest.raises(ValueError):
-        check_encode_decode_array_to_bytes(arrays[0], codec)
+        check_encode_decode_array(arrays[0], codec)
 
 
 def test_repr():


### PR DESCRIPTION
Decoding with PCodec is causing issues in upstream zarr because it's being expected to handle numpy arrays. It seems like the other codecs in this library perform input validation in their respective implementations and generally support numpy arrays as a buffer-like. 

This PR:
- calls `ensure_bytes` on the input type for `PCodec.decode()`
- updates unit tests. the former `check_encode_decode_array_to_bytes` seems to be a more restrictive version of `check_encode_decode_array`.

ref: https://github.com/zarr-developers/zarr-python/issues/3176

TODO:

- [x] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
