### PR TITLE
CI: add a nightly wheel upload

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -1,6 +1,12 @@
 name: Wheels
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  schedule:
+    # Run at 2:00 AM UTC daily
+    - cron: '0 2 * * *'
+  workflow_dispatch:  # Allow manual trigger
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -96,3 +102,20 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_password }}
           # To test: repository_url: https://test.pypi.org/legacy/
+
+  upload_nightly:
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Upload to scientific-python nightly channel
+        uses: scientific-python/upload-nightly-action@b36e8c0c10dbcfd2e05bf95f17ef8c14fd708dbf
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_token: ${{ secrets.ANACONDA_NIGHTLY_UPLOAD_TOKEN }}

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -1,6 +1,6 @@
 name: Wheels
 
-on: 
+on:
   push:
   pull_request:
   schedule:


### PR DESCRIPTION
Nightly upload the anaconda scipy-nightly-wheels channel to enable easier testing by downstream packages

Attn @jhamman 