### PR TITLE
fetch tags to version nightly wheels correctly

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # required for version resolution for nightly wheels
 
       - uses: pypa/cibuildwheel@v2.23.2
 
@@ -46,6 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         name: Install Python


### PR DESCRIPTION
Add a line to fetch more history in the wheels action so that the nightly wheel gets the correct version. The main release wheels worked because they were always garunteed to be on a tag instead of some random commit hash

Fixes the versions here: https://anaconda.org/scientific-python-nightly-wheels/numcodecs/files

@jhamman 