### PR TITLE
Test against zarr main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zarr-version: ["312", "313"]
+        zarr-version: ["312", "313", "main"]
 
     defaults:
       run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,12 @@ test-zarr-313 = [
     "zarr==3.1.3",
     "crc32c",
 ]
+test-zarr-main = [
+    "pytest",
+    "pytest-cov",
+    "zarr @ git+https://github.com/zarr-developers/zarr-python.git@main",
+    "crc32c",
+]
 
 msgpack = [
     "msgpack",
@@ -240,7 +246,8 @@ conflicts = [
     # Zarr versions conflict with each other
     [
         { group = "test-zarr-312" },
-        { group = "test-zarr-313" }
+        { group = "test-zarr-313" },
+        { group = "test-zarr-main" }
     ]
 ]
 
@@ -257,5 +264,7 @@ uv = "*"
 [tool.pixi.tasks]
 ls-deps-312 = "uv run --group test-zarr-312 uv pip freeze"
 ls-deps-313 = "uv run --group test-zarr-313 uv pip freeze"
+ls-deps-main = "uv run --group test-zarr-main uv pip freeze"
 test-zarr-312 = "uv run --group test-zarr-312 pytest numcodecs/tests/test_zarr3.py numcodecs/tests/test_zarr3_import.py"
 test-zarr-313 = "uv run --group test-zarr-313 pytest numcodecs/tests/test_zarr3.py numcodecs/tests/test_zarr3_import.py"
+test-zarr-main = "uv run --group test-zarr-main pytest numcodecs/tests/test_zarr3.py numcodecs/tests/test_zarr3_import.py"


### PR DESCRIPTION
While there's redundancy with zarr's tests against numcodecs main, I think an extra layer of safety wouldn't hurt so this adds a test env with Zarr's main branch.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
