### PR TITLE
Fix `ZFPY` contiguous array error when used in Zarr

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -17,6 +17,13 @@ Release notes
 Unreleased
 ----------
 
+
+Fixes
+~~~~~
+
+* Fix Zarr serialization with ZFP when array is a view.
+  By :user:`Altay Sansal <tasansal>`, :issue:`812`
+
 .. _release_0.16.5:
 
 0.16.5

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -77,13 +77,16 @@ if _zfpy:
                     "The zfp codec does not support none numpy arrays."
                     f" Your buffers were {type(buf)}."
                 )
-            if buf.flags.c_contiguous:
-                flatten = False
-            else:
+            if buf.flags.f_contiguous:
                 raise ValueError(
                     "The zfp codec does not support F order arrays. "
                     f"Your arrays flags were {buf.flags}."
                 )
+            # Force C-contiguous if needed (copies only if not already C-contiguous)
+            buf = np.ascontiguousarray(buf)
+            
+            # No flattening needed for C-order
+            flatten = False
             buf = ensure_contiguous_ndarray(buf, flatten=flatten)
 
             # do compression

--- a/numcodecs/zfpy.py
+++ b/numcodecs/zfpy.py
@@ -84,7 +84,7 @@ if _zfpy:
                 )
             # Force C-contiguous if needed (copies only if not already C-contiguous)
             buf = np.ascontiguousarray(buf)
-            
+
             # No flattening needed for C-order
             flatten = False
             buf = ensure_contiguous_ndarray(buf, flatten=flatten)


### PR DESCRIPTION
Fixes #812 

With Zarr v3 and using `zarr.codecs.ZFPY` as serializer, the ZFP compressor logic in `numcodecs` complains that it is not F-order data. The chunk data neither C/F contiguous when it is a sliced view of an existing array. I traced it down to the logic here, and this PR addresses the issue. 

https://github.com/zarr-developers/numcodecs/blob/e0ddee6b6d01bfd35a91085ec0a20dae6bf50e13/numcodecs/zfpy.py#L80-L87

By making the check more explicit and applying `np.ascontiguous` after ensuring it not F-order, the issue goes away.

---

Reproducer

```Python
import numpy as np
import asyncio
import zarr
from zarr.storage import MemoryStore
from zarr import create_array
from zarr.codecs import numcodecs

# fixed accuracy
zfp = numcodecs.ZFPY(mode=4, tolerance=0.001)
store = MemoryStore()

zfp_arr = create_array(
    store,
    shape=(100, 100, 100),
    chunks=(50, 50, 100),
    dtype="float32",
    serializer=zfp,
    compressors=None
)

rng = np.random.default_rng()
data = rng.random(zfp_arr.shape)
zfp_arr[:] = data
```

Raises:

```python
ValueError: The zfp codec does not support F order arrays. Your arrays flags were   C_CONTIGUOUS : False
  F_CONTIGUOUS : False
  OWNDATA : False
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
.
```

If we look at the chunk slices' numpy flags:

```python
>>> data[:50, :50, :].flags.c_contiguous
False
>>> data[:50, 50:, :].flags.c_contiguous
False
>>> data[50:, 50:, :].flags.c_contiguous
False
>>> data[50:, :50, :].flags.c_contiguous
False
```

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [x] Changes documented in docs/release.rst
- [x] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
