### PR TITLE
Documentation cleanup: fix typos, grammar, and naming consistency

### DIFF
--- a/docs/compression/zstd.rst
+++ b/docs/compression/zstd.rst
@@ -7,9 +7,6 @@ Zstd
     .. autoattribute:: codec_id
     .. automethod:: encode
     .. automethod:: decode
-        .. note::
-            If the compressed data does not contain the decompressed size, streaming
-            decompression will be used.
     .. automethod:: get_config
     .. automethod:: from_config
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -9,10 +9,10 @@ Asking for help
 ---------------
 
 If you have a question about how to use NumCodecs, please post your question on
-StackOverflow using the `"numcodecs" tag <https://stackoverflow.com/questions/tagged/numcodecs>`_.
+Stack Overflow using the `"numcodecs" tag <https://stackoverflow.com/questions/tagged/numcodecs>`_.
 If you don't get a response within a day or two, feel free to raise a `GitHub issue
 <https://github.com/zarr-developers/numcodecs/issues/new>`_ including a link to your
-StackOverflow question. We will try to respond to questions as quickly as possible, but
+Stack Overflow question. We will try to respond to questions as quickly as possible, but
 please bear in mind that there may be periods where we have limited time to answer
 questions due to other commitments.
 
@@ -148,12 +148,12 @@ docstrings. The simplest way to run the unit tests is to invoke::
 
     $ pytest -v
 
-NumCodecs currently supports Python 6-3.9, so the above command must
+NumCodecs currently supports Python 3.11+, so the above command must
 succeed before code can be accepted into the main code base.
 
-All tests are automatically run via Travis (Linux) and AppVeyor (Windows) continuous
-integration services for every pull request. Tests must pass under both services before
-code can be accepted.
+All tests are automatically run via GitHub Actions continuous
+integration services for every pull request. Tests must pass
+before code can be accepted.
 
 Code standards
 ~~~~~~~~~~~~~~
@@ -167,8 +167,7 @@ Conformance can be checked by running::
 Test coverage
 ~~~~~~~~~~~~~
 
-NumCodecs maintains 100% test coverage under the latest Python stable release (currently
-Python 3.9). Both unit tests and docstring doctests are included when computing
+NumCodecs maintains 100% test coverage under the latest Python stable release. Both unit tests and docstring doctests are included when computing
 coverage. Running ``pytest -v`` will automatically run the test suite with coverage
 and produce a coverage report. This should be 100% before code can be accepted into the
 main code base.
@@ -182,8 +181,7 @@ Documentation
 
 Docstrings for user-facing classes and functions should follow the `numpydoc
 <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ standard,
-including sections for Parameters and Examples. All examples will be run as doctests
-under Python 3.9.
+including sections for Parameters and Examples. All examples will be run as doctests.
 
 NumCodecs uses Sphinx for documentation, hosted on readthedocs.org. Documentation is
 written in the RestructuredText markup language (.rst files) in the ``docs`` folder.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Installation
 
 Numcodecs depends on NumPy. It is generally best to `install NumPy
 <https://numpy.org/install/>`_ first using whatever method is most
-appropriate for you operating system and Python distribution.
+appropriate for your operating system and Python distribution.
 
 Install from PyPI::
 
@@ -51,7 +51,7 @@ and then install in editable mode using `pip`.::
     $ pip install -e .[test,msgpack,zfpy]
 
 Note: if you prefer to use the GitHub CLI ``gh`` you will need to append ``-- --recurse-submodules``
-to the clone command to everything works properly.
+to the clone command to ensure everything works properly.
 
 To verify that Numcodecs has been fully installed (including the Blosc
 extension) run the test suite::

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -48,7 +48,7 @@ Enhancements
 Fixes
 ~~~~~
 
-* Fix ``PCodec.decode()`` to handle numpy arrays by calling ``ensure_bytes`` on input buffers.
+* Fix ``PCodec.decode()`` to handle NumPy arrays by calling ``ensure_bytes`` on input buffers.
   By :user:`Sam Levang <slowjazz>`, :issue:`756`
 
 Maintenance
@@ -180,14 +180,14 @@ Enhancements
   By :user:`Agriya Khetarpal <agriyakhetarpal>`, :issue:`288`.
 * Preallocate output buffers and resize directly as needed.
   By :user:`John Kirkham <jakirkham>`, :issue:`656`
-* ``Checksum32`` is now an abstract base clase, with ``checksum()`` as an abstract method.
+* ``Checksum32`` is now an abstract base class, with ``checksum()`` as an abstract method.
   This helps ensure that any subclasses implement the ``checksum()`` method.
   :issue:`711`
 
 Removals
 ~~~~~~~~
 
-The following ``blosc`` funcitons are removed, with no replacement.
+The following ``blosc`` functions are removed, with no replacement.
 This is because they were not intended to be public API.
 
 - ``numcodecs.blosc.init``
@@ -198,7 +198,7 @@ This is because they were not intended to be public API.
 
 In addition, ``numcodecs.blosc.decompress_partial`` is removed as
 has always been experimental and there is no equivalent in the official
-blsoc Python package.
+blosc Python package.
 By :user:`David Stansby <dstansby>`, :issue:`712`
 
 Maintenance
@@ -248,7 +248,7 @@ This is because they are not intended to be public API.
 
 In addition, ``numcodecs.blosc.decompress_partial`` is deprecated as
 has always been experimental and there is no equivalent in the official
-blsoc Python package.
+blosc Python package.
 By :user:`David Stansby <dstansby>`, :issue:`619`
 
 Fixes
@@ -329,7 +329,7 @@ Maintenance
 ~~~~~~~~~~~
 * The minimum supported Python version is now Python 3.11.
   By :user:`David Stansby <dstansby>`, :issue:`622`
-* The minimum supported numpy version is now 1.24.
+* The minimum supported NumPy version is now 1.24.
   By :user:`David Stansby <dstansby>`, :issue:`622`
 
 .. _release_0.13.1:
@@ -387,17 +387,17 @@ Fix
   By :user:`Elliott Sales de Andrade <QuLogic>`, :issue:`487`.
 * Fix Upgrade to Zstd 1.5.5 due to potential corruption.
   By :user:`Mark Kittisopikul <mkitti>`, :issue:`429`
-* Add version constraint(<2.0) for numpy in zfpy.
+* Add version constraint(<2.0) for NumPy in zfpy.
   By :user:`Tom Liang <px39n>`, :issue:`540`.
 
 Maintenance
 ~~~~~~~~~~~
 * The minimum supported Python version is now Python 3.10.
   By :user:`David Stansby <dstansby>`, :issue:`531`
-* Add numpy 2 compatibility.
+* Add NumPy 2 compatibility.
   By :user:`David Stansby <dstansby>`, :issue:`535`
 * Update c-blosc to 1.21.0 to 1.21.5, zstd from 1.4.8 to 1.5.5,
-  lz4 from 1.9.3 to 1.9.4, and zlib from 1.2.8 to to 1.2.13
+  lz4 from 1.9.3 to 1.9.4, and zlib from 1.2.8 to 1.2.13
   By :user:`Mark Kittisopikul <mkitti>`, :issue:`500`
 
 
@@ -483,7 +483,7 @@ Maintenance
   By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`369`.
 
 * Drop Python 3.7.
-  By :user:`John Kirkham <jakirkham>`,, :issue:`405` :issue:`406`.
+  By :user:`John Kirkham <jakirkham>`, :issue:`405` :issue:`406`.
 
 * Test with zfpy 1.0.0.
   By :user:`John Kirkham <jakirkham>`, :issue:`385`.
@@ -715,7 +715,7 @@ Maintenance
 * Automatically release to PyPI.
   By :user:`Josh Moore <joshmoore>`, :issue:`241`.
 
-* Build wheels on github actions.
+* Build wheels on GitHub Actions.
   By :user:`Grzegorz Bokota <Czaki>`, :issue:`224`.
 
 * Add Base64 codec.
@@ -872,7 +872,7 @@ Maintenance
   code readability and maintainability. By :user:`John Kirkham <jakirkham>` and
   :user:`Alistair Miles <alimanfoo>`; :issue:`119`, :issue:`121`, :issue:`128`.
 
-* Return values from encode() and decode() methods are now returned as numpy
+* Return values from encode() and decode() methods are now returned as NumPy
   arrays for consistency across codecs. By :user:`John Kirkham <jakirkham>`,
   :issue:`136`.
 

--- a/numcodecs/zstd.pyx
+++ b/numcodecs/zstd.pyx
@@ -439,6 +439,13 @@ class Zstd(Codec):
         return compress(buf, self.level, self.checksum)
 
     def decode(self, buf, out=None):
+        """
+        Notes
+        -----
+        If the compressed data does not contain the decompressed size, streaming
+        decompression will be used.
+
+        """
         buf = ensure_contiguous_ndarray(buf)
         return decompress(buf, out)
 


### PR DESCRIPTION
TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
