### PR TITLE
Switch from pyzstd to compression.zstd

### DIFF
--- a/numcodecs/tests/test_pyzstd.py
+++ b/numcodecs/tests/test_pyzstd.py
@@ -2,7 +2,13 @@
 
 import numpy as np
 import pytest
-import pyzstd
+try:
+    from compression import zstd as pyzstd
+except ImportError:
+    try:
+       from backports import zstd as pyzstd
+    except ImportError:
+        import pyzstd
 
 from numcodecs.zstd import Zstd
 
@@ -56,7 +62,6 @@ def test_pyzstd_streaming(input):
     """
     pyzstd_c = pyzstd.ZstdCompressor()
     pyzstd_d = pyzstd.ZstdDecompressor()
-    pyzstd_e = pyzstd.EndlessZstdDecompressor()
     z = Zstd()
 
     d_bytes = input
@@ -66,11 +71,11 @@ def test_pyzstd_streaming(input):
     assert pyzstd_d.decompress(z.encode(d_bytes)) == d_bytes
 
     # Test multiple streaming frames
-    assert z.decode(c_bytes * 2) == pyzstd_e.decompress(c_bytes * 2)
-    assert z.decode(c_bytes * 3) == pyzstd_e.decompress(c_bytes * 3)
-    assert z.decode(c_bytes * 4) == pyzstd_e.decompress(c_bytes * 4)
-    assert z.decode(c_bytes * 5) == pyzstd_e.decompress(c_bytes * 5)
-    assert z.decode(c_bytes * 7) == pyzstd_e.decompress(c_bytes * 7)
-    assert z.decode(c_bytes * 11) == pyzstd_e.decompress(c_bytes * 11)
-    assert z.decode(c_bytes * 13) == pyzstd_e.decompress(c_bytes * 13)
-    assert z.decode(c_bytes * 99) == pyzstd_e.decompress(c_bytes * 99)
+    assert z.decode(c_bytes * 2) == pyzstd.decompress(c_bytes * 2)
+    assert z.decode(c_bytes * 3) == pyzstd.decompress(c_bytes * 3)
+    assert z.decode(c_bytes * 4) == pyzstd.decompress(c_bytes * 4)
+    assert z.decode(c_bytes * 5) == pyzstd.decompress(c_bytes * 5)
+    assert z.decode(c_bytes * 7) == pyzstd.decompress(c_bytes * 7)
+    assert z.decode(c_bytes * 11) == pyzstd.decompress(c_bytes * 11)
+    assert z.decode(c_bytes * 13) == pyzstd.decompress(c_bytes * 13)
+    assert z.decode(c_bytes * 99) == pyzstd.decompress(c_bytes * 99)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "coverage",
     "pytest",
     "pytest-cov",
-    "pyzstd"
+    "backports.zstd ; python_version<'3.14'"
 ]
 test_extras = [
     "importlib_metadata",


### PR DESCRIPTION
[Description of PR]

Python v3.14 introduces the `compression.zstd` module (derived from pyzsrd).
For Python versions lower than v3.14 the `backports.zstd` module is now available.

This patch modifies teh test code to use `compression.zsrd` intead of the old and deprecated `pyzstd` module.

TODO:

- [X] Unit tests and/or doctests in docstrings
- [X] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [X] Docs build locally
- [X] GitHub Actions CI passes
- [X] Test coverage to 100% (Codecov passes)
