### PR TITLE
Exclude tests dir from code coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,9 @@ write_to = "numcodecs/version.py"
 skip = "./.git,fixture"
 ignore-words-list = "ba, compiletime, hist, nd, unparseable"
 
+[tool.coverage.run]
+omit = ["numcodecs/tests/*"]
+
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
The tests dir is bringing down are code coverage statistics, but doesn't need to be included. This configures pytest to ignore that folder when computing coverage statistics.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
