### PR TITLE
Update README to markdown with working badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Numcodecs
+
+Numcodecs is a Python package providing buffer compression and transformation
+codecs for use in data storage and communication applications.
+
+[![Docs](https://readthedocs.org/projects/numcodecs/badge/?version=latest)](https://numcodecs.readthedocs.io/en/latest/?badge=latest)
+[![Tests](https://github.com/zarr-developers/numcodecs/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/zarr-developers/numcodecs/actions/workflows/ci.yaml)
+[![Wheels](https://github.com/zarr-developers/numcodecs/actions/workflows/wheel.yaml/badge.svg?branch=main)](https://github.com/zarr-developers/numcodecs/actions/workflows/wheel.yaml)
+[![Codecov](https://codecov.io/gh/zarr-developers/numcodecs/branch/main/graph/badge.svg)](https://codecov.io/gh/zarr-developers/numcodecs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "numcodecs"
 description = """
 A Python package providing buffer compression and transformation codecs \
 for use in data storage and communication applications."""
-readme = "README.rst"
+readme = "README.md"
 dependencies = ["numpy>=1.24", "typing_extensions"]
 requires-python = ">=3.11"
 dynamic = [


### PR DESCRIPTION
One of the readme badges was broken, this fixes that while converting to markdown for easier maintenance.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
