### PR TITLE
Drop Python 3.11 and NumPy <2.0 per SPEC-0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
         # macos-15-large is an intel runner, macos-14 is an arm64 runner
         platform: [ubuntu-latest, ubuntu-22.04-arm, windows-latest, macos-15-large, macos-14]
 
@@ -129,10 +129,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - zarr-version: "312"
-            zarr-pkg: "zarr==3.1.2"
-          - zarr-version: "313"
-            zarr-pkg: "zarr==3.1.3"
+          - zarr-version: "308"
+            zarr-pkg: "zarr==3.0.8"
+          - zarr-version: "316"
+            zarr-pkg: "zarr==3.1.6"
           - zarr-version: "main"
             zarr-pkg: "zarr @ git+https://github.com/zarr-developers/zarr-python.git@main"
 

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-22.04-arm, windows-latest, macos-15-large, macos-14]
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"
-      CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp312-* cp313-* cp314-*"
       CIBW_SKIP: "*-musllinux_* *win32 *_i686 *_s390x"
       # note: cibuildwheel config-settings are set in pyproject.toml
 
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -256,7 +256,7 @@ $ pytest tests/test_checksum32.py -v
 ```
 
 All tests are automatically run via GitHub Actions for every pull request across Linux
-(x86_64, aarch64, i386), macOS (x86_64, arm64), and Windows (x86_64), with Python 3.11
+(x86_64, aarch64, i386), macOS (x86_64, arm64), and Windows (x86_64), with Python 3.12
 through 3.14. Tests must pass on all platforms before code can be accepted.
 
 ### Code standards

--- a/docs/design/meson-python-migration.md
+++ b/docs/design/meson-python-migration.md
@@ -609,7 +609,7 @@ To run tests for specific Zarr integration versions::
 
 All tests are automatically run via GitHub Actions for every pull request
 across Linux (x86_64, aarch64, i386), macOS (x86_64, arm64), and Windows
-(x86_64), with Python 3.11 through 3.14.
+(x86_64), with Python 3.12 through 3.14.
 ```
 
 ### Other sections to update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ description = """
 A Python package providing buffer compression and transformation codecs \
 for use in data storage and communication applications."""
 readme = "README.md"
-dependencies = ["numpy>=1.24", "typing_extensions"]
-requires-python = ">=3.11"
+dependencies = ["numpy>=2.0", "typing_extensions"]
+requires-python = ">=3.12"
 dynamic = [
   "version",
 ]
@@ -89,16 +89,16 @@ dev = [
     "setuptools-scm>=6.2",
     "numpy>=2",
 ]
-test-zarr-312 = [
+test-zarr-308 = [
     "pytest",
     "pytest-cov",
-    "zarr==3.1.2",
+    "zarr==3.0.8",
     "crc32c",
 ]
-test-zarr-313 = [
+test-zarr-316 = [
     "pytest",
     "pytest-cov",
-    "zarr==3.1.3",
+    "zarr==3.1.6",
     "crc32c",
 ]
 test-zarr-main = [
@@ -249,8 +249,8 @@ no-build-isolation-package = ["numcodecs"]
 conflicts = [
     # Zarr versions conflict with each other
     [
-        { group = "test-zarr-312" },
-        { group = "test-zarr-313" },
+        { group = "test-zarr-308" },
+        { group = "test-zarr-316" },
         { group = "test-zarr-main" }
     ]
 ]

--- a/src/numcodecs/checksum32.py
+++ b/src/numcodecs/checksum32.py
@@ -3,11 +3,10 @@ import importlib.util
 import struct
 import warnings
 import zlib
-from collections.abc import Callable
+from collections.abc import Buffer, Callable
 from typing import Literal
 
 import numpy as np
-from typing_extensions import Buffer
 
 from .abc import Codec
 from .compat import ensure_contiguous_ndarray, ndarray_copy


### PR DESCRIPTION
Apply scientific-python SPEC-0 support policy:
- Python minimum 3.11 -> 3.12 (3.11 released Oct 2022, 3-year window expired)
- NumPy minimum 1.24 -> 2.0 (1.24 released Dec 2022, 2-year window expired)
- Zarr test pins 3.1.2/3.1.3 -> 3.0.8/3.1.6 (oldest supported + latest)

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
