### PR TITLE
chore: update pre-commit hook mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,9 +25,9 @@ repos:
     hooks:
     - id: sp-repo-review
 
-  -   repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.16.0
-      hooks:
-      -   id: mypy
-          args: [--config-file, pyproject.toml]
-          additional_dependencies: [numpy, pytest, google-crc32c, crc32c, zfpy, 'zarr>=3.1.3']
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.20.0
+    hooks:
+    - id: mypy
+      args: [--config-file, pyproject.toml]
+      additional_dependencies: [numpy, pytest, google-crc32c, crc32c, zfpy, 'zarr>=3.1.3']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,9 +25,9 @@ repos:
     hooks:
     - id: sp-repo-review
 
-  -   repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.16.0
-      hooks:
-      -   id: mypy
-          args: [--config-file, pyproject.toml]
-          additional_dependencies: [numpy, pytest, google-crc32c, crc32c, zfpy, 'zarr>=3.1.3']
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.20.2
+    hooks:
+    - id: mypy
+      args: [--config-file, pyproject.toml]
+      additional_dependencies: [numpy, pytest, google-crc32c, crc32c, zfpy, 'zarr>=3.1.3']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     - id: sp-repo-review
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.2
+    rev: v2.1.0
     hooks:
     - id: mypy
       args: [--config-file, pyproject.toml]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,3 +23,4 @@ python:
         - msgpack
         - zfpy
         - crc32c
+        - numpydoc

--- a/tests/test_zarr3.py
+++ b/tests/test_zarr3.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:  # pragma: no cover
-    import zarr
+    import zarr.codecs
 else:
-    zarr = pytest.importorskip("zarr", "3.1.3")
+    zarr = pytest.importorskip("zarr.codecs", "3.1.3")
 
 import numcodecs.zarr3 as zarr3
 


### PR DESCRIPTION
updates:
- github.com/pre-commit/mirrors-mypy: v1.16.0 → v2.1.0

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [x] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
