### PR TITLE
CI: Fix Meson mixup between Conda and system Python headers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,9 @@ jobs:
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}
 
-      - name: Install compilers
-        run: conda install -y c-compiler cxx-compiler
+      - name: Install build dependencies and compilers
+        run: |
+          conda install -y python numpy cython meson meson-python ninja c-compiler cxx-compiler
 
       - name: Install clang
         if: matrix.platform == 'macos-15-large'
@@ -47,21 +48,33 @@ jobs:
           conda config --show-sources
           conda list --show-channel-urls
 
+      - name: Meson args - prefer Conda over system Python (Ubuntu)
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          echo "MESONPY_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> $GITHUB_ENV
+          PY_INC="$(python -c 'import sysconfig; print(sysconfig.get_path("include"))')"
+          echo "CFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CFLAGS:-}" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CPPFLAGS:-}" >> $GITHUB_ENV
+          echo "LDFLAGS=-L${CONDA_PREFIX}/lib ${LDFLAGS:-}" >> $GITHUB_ENV
+
       - name: Install numcodecs
         run: |
           # TODO: Remove this conditional when pcodec supports Python 3.14
           if [[ "${{ matrix.python-version }}" == "3.14" ]]; then
-            python -m pip install -v ".[test,test_extras,msgpack,google_crc32c,crc32c,zfpy]"
+            python -m pip install -v \
+              ".[test,test_extras,msgpack,google_crc32c,crc32c,zfpy]" \
+              pytest
           else
-            python -m pip install -v ".[test,test_extras,msgpack,google_crc32c,crc32c,pcodec,zfpy]"
+            python -m pip install -v \
+              ".[test,test_extras,msgpack,google_crc32c,crc32c,pcodec,zfpy]" \
+              pytest
           fi
 
       - name: List installed packages
         run: python -m pip list
 
       - name: Run tests
-        shell: "bash -l {0}"
-        run: pytest -v
+        run: python -m pytest -v
 
       - uses: codecov/codecov-action@v5
         with:
@@ -100,8 +113,17 @@ jobs:
           miniforge-version: latest
           python-version: "3.13"
 
-      - name: Install compilers
-        run: conda install -y c-compiler cxx-compiler
+      - name: Install build dependencies and compilers
+        run: |
+          conda install -y python numpy cython meson meson-python ninja c-compiler cxx-compiler
+
+      - name: Meson args - prefer Conda over system Python (Ubuntu)
+        run: |
+          echo "MESONPY_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> $GITHUB_ENV
+          PY_INC="$(python -c 'import sysconfig; print(sysconfig.get_path("include"))')"
+          echo "CFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CFLAGS:-}" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CPPFLAGS:-}" >> $GITHUB_ENV
+          echo "LDFLAGS=-L${CONDA_PREFIX}/lib ${LDFLAGS:-}" >> $GITHUB_ENV
 
       - name: Install numcodecs
         run: |
@@ -115,7 +137,7 @@ jobs:
         run: python -m pip list
 
       - name: Run checksum tests
-        run: pytest -v tests/test_checksum32.py
+        run: python -m pytest -v tests/test_checksum32.py
 
       - uses: codecov/codecov-action@v5
         with:
@@ -154,17 +176,26 @@ jobs:
           miniforge-version: latest
           python-version: "3.13"
 
-      - name: Install compilers
-        run: conda install -y c-compiler cxx-compiler
+      - name: Install build dependencies and compilers
+        run: |
+          conda install -y python numpy cython meson meson-python ninja c-compiler cxx-compiler
+
+      - name: Meson args - prefer Conda over system Python (Ubuntu)
+        run: |
+          echo "MESONPY_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> $GITHUB_ENV
+          PY_INC="$(python -c 'import sysconfig; print(sysconfig.get_path("include"))')"
+          echo "CFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CFLAGS:-}" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CPPFLAGS:-}" >> $GITHUB_ENV
+          echo "LDFLAGS=-L${CONDA_PREFIX}/lib ${LDFLAGS:-}" >> $GITHUB_ENV
 
       - name: Install numcodecs and Zarr
         run: |
-          python -m pip install -v ".[test,test_extras]" "${{ matrix.zarr-pkg }}" crc32c
+          python -m pip install -v  ".[test,test_extras]" "${{ matrix.zarr-pkg }}" crc32c
       - name: List installed packages
         run: python -m pip list
 
       - name: Run Zarr integration tests
-        run: pytest tests/test_zarr3.py tests/test_zarr3_import.py
+        run: python -m pytest tests/test_zarr3.py tests/test_zarr3_import.py
 
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,8 @@ jobs:
           channels: conda-forge
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}
+          activate-environment: test
+          auto-activate-base: false
 
       - name: Install build dependencies and compilers
         run: |
@@ -112,6 +114,8 @@ jobs:
           channels: conda-forge
           miniforge-version: latest
           python-version: "3.13"
+          activate-environment: test
+          auto-activate-base: false
 
       - name: Install build dependencies and compilers
         run: |
@@ -175,6 +179,8 @@ jobs:
           channels: conda-forge
           miniforge-version: latest
           python-version: "3.13"
+          activate-environment: test
+          auto-activate-base: false
 
       - name: Install build dependencies and compilers
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,56 +27,27 @@ jobs:
           submodules: recursive
           fetch-depth: 0 # required for version resolution
 
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3.2.0
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          channels: conda-forge
-          miniforge-version: latest
           python-version: ${{ matrix.python-version }}
-          activate-environment: test
-          auto-activate-base: false
-
-      - name: Install build dependencies and compilers
-        run: |
-          conda install -y python numpy cython meson meson-python ninja c-compiler cxx-compiler
-
-      - name: Install clang
-        if: matrix.platform == 'macos-15-large'
-        run: conda install -y 'clang>=12.0.1,<17'
-
-      - name: Show conda environment info
-        run: |
-          conda info
-          conda config --show-sources
-          conda list --show-channel-urls
-
-      - name: Meson args - prefer Conda over system Python (Ubuntu)
-        if: startsWith(matrix.platform, 'ubuntu')
-        run: |
-          echo "MESONPY_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> $GITHUB_ENV
-          PY_INC="$(python -c 'import sysconfig; print(sysconfig.get_path("include"))')"
-          echo "CFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CFLAGS:-}" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CPPFLAGS:-}" >> $GITHUB_ENV
-          echo "LDFLAGS=-L${CONDA_PREFIX}/lib ${LDFLAGS:-}" >> $GITHUB_ENV
+          cache: 'pip'
 
       - name: Install numcodecs
         run: |
           # TODO: Remove this conditional when pcodec supports Python 3.14
           if [[ "${{ matrix.python-version }}" == "3.14" ]]; then
-            python -m pip install -v \
-              ".[test,test_extras,msgpack,google_crc32c,crc32c,zfpy]" \
-              pytest
+            python -m pip install -v ".[test,test_extras,msgpack,google_crc32c,crc32c,zfpy]"
           else
-            python -m pip install -v \
-              ".[test,test_extras,msgpack,google_crc32c,crc32c,pcodec,zfpy]" \
-              pytest
+            python -m pip install -v ".[test,test_extras,msgpack,google_crc32c,crc32c,pcodec,zfpy]"
           fi
 
       - name: List installed packages
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -v
+        shell: "bash -l {0}"
+        run: pytest -v
 
       - uses: codecov/codecov-action@v5
         with:
@@ -108,26 +79,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3.2.0
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          channels: conda-forge
-          miniforge-version: latest
-          python-version: "3.13"
-          activate-environment: test
-          auto-activate-base: false
-
-      - name: Install build dependencies and compilers
-        run: |
-          conda install -y python numpy cython meson meson-python ninja c-compiler cxx-compiler
-
-      - name: Meson args - prefer Conda over system Python (Ubuntu)
-        run: |
-          echo "MESONPY_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> $GITHUB_ENV
-          PY_INC="$(python -c 'import sysconfig; print(sysconfig.get_path("include"))')"
-          echo "CFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CFLAGS:-}" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CPPFLAGS:-}" >> $GITHUB_ENV
-          echo "LDFLAGS=-L${CONDA_PREFIX}/lib ${LDFLAGS:-}" >> $GITHUB_ENV
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install numcodecs
         run: |
@@ -141,7 +97,7 @@ jobs:
         run: python -m pip list
 
       - name: Run checksum tests
-        run: python -m pytest -v tests/test_checksum32.py
+        run: pytest -v tests/test_checksum32.py
 
       - uses: codecov/codecov-action@v5
         with:
@@ -173,35 +129,20 @@ jobs:
           submodules: recursive
           fetch-depth: 0 # required for version resolution
 
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3.2.0
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          channels: conda-forge
-          miniforge-version: latest
-          python-version: "3.13"
-          activate-environment: test
-          auto-activate-base: false
-
-      - name: Install build dependencies and compilers
-        run: |
-          conda install -y python numpy cython meson meson-python ninja c-compiler cxx-compiler
-
-      - name: Meson args - prefer Conda over system Python (Ubuntu)
-        run: |
-          echo "MESONPY_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> $GITHUB_ENV
-          PY_INC="$(python -c 'import sysconfig; print(sysconfig.get_path("include"))')"
-          echo "CFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CFLAGS:-}" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I${PY_INC} -I${CONDA_PREFIX}/include ${CPPFLAGS:-}" >> $GITHUB_ENV
-          echo "LDFLAGS=-L${CONDA_PREFIX}/lib ${LDFLAGS:-}" >> $GITHUB_ENV
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install numcodecs and Zarr
         run: |
-          python -m pip install -v  ".[test,test_extras]" "${{ matrix.zarr-pkg }}" crc32c
+          python -m pip install -v ".[test,test_extras]" "${{ matrix.zarr-pkg }}" crc32c
       - name: List installed packages
         run: python -m pip list
 
       - name: Run Zarr integration tests
-        run: python -m pytest tests/test_zarr3.py tests/test_zarr3_import.py
+        run: pytest tests/test_zarr3.py tests/test_zarr3_import.py
 
       - uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
~~Fix CI failure. Convince Meson to pick Python headers installed by Conda, not system-wide headers.~~

~~This really feels like a hack. I don't know enough about meson to understand and fix this mess cleanly. There has to be a way though, Meson cannot be that broken. Any clues?~~

**Edit:** A better strategy is probably to remove Conda altogether, used primarily to install C/C++ compilers, as C/C++ compilers are readily available in GitHub runners.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [x] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [x] GitHub Actions CI passes
- [x] Test coverage to 100% (Codecov passes)
