### PR TITLE
zarr-python does not depend on crc32c anymore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ test = [
 ]
 test_extras = [
     "importlib_metadata",
-    "crc32c",  # TODO: remove once zarr-python does not depend on crc32c anymore
 ]
 
 [dependency-groups]


### PR DESCRIPTION
See https://github.com/zarr-developers/zarr-python/commit/d005ff77bc4efaf52f8e43d17f11d27f43d19ee0.

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
