### PR TITLE
PEP 735: `optional-dependencies` → `dependency-groups`

### DIFF
--- a/.github/workflows/ci-i386.yml
+++ b/.github/workflows/ci-i386.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install zfp and numcodecs
         run: |
           uv venv
-          uv pip install --group dev
+          uv pip install --group dev --group test --group  test-extras
           PYTHON_INCLUDE=$(uv run python -c 'from sysconfig import get_paths; print(get_paths()["include"])');
           PYTHON_LIB=$(uv run python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))');
           git clone https://github.com/LLNL/zfp
@@ -59,7 +59,7 @@ jobs:
           uv run sudo make -C zfp/build install
           uv pip install ./zfp
           uv pip install --no-build-isolation -v .
-          uv pip install "numcodecs[test,test_extras,msgpack,google_crc32c,crc32c,zfpy]"
+          uv pip install "numcodecs[msgpack,google_crc32c,crc32c,zfpy]"
         shell: alpine.sh {0}
 
       - name: List installed packages

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,9 +51,13 @@ jobs:
         run: |
           # TODO: Remove this conditional when pcodec supports Python 3.14
           if [[ "${{ matrix.python-version }}" == "3.14" ]]; then
-            python -m pip install -v ".[test,test_extras,msgpack,google_crc32c,crc32c,zfpy]"
+            python -m pip install -v \
+              --group test --group test_extras \
+              ".[msgpack,google_crc32c,crc32c,zfpy]"
           else
-            python -m pip install -v ".[test,test_extras,msgpack,google_crc32c,crc32c,pcodec,zfpy]"
+            python -m pip install -v \
+              --group test --group test_extras \
+              ".[msgpack,google_crc32c,crc32c,pcodec,zfpy]"
           fi
 
       - name: List installed packages
@@ -106,9 +110,9 @@ jobs:
       - name: Install numcodecs
         run: |
           if [[ -n "${{ matrix.extras }}" ]]; then
-            python -m pip install -v ".[${{ matrix.extras }},test]"
+            python -m pip install -v --group test ".[${{ matrix.extras }}]"
           else
-            python -m pip install -v ".[test]"
+            python -m pip install -v --group test .
           fi
 
       - name: List installed packages
@@ -159,7 +163,9 @@ jobs:
 
       - name: Install numcodecs and Zarr
         run: |
-          python -m pip install -v ".[test,test_extras]" "${{ matrix.zarr-pkg }}" crc32c
+          python -m pip install -v \
+            --group test --group test_extras \
+           . "${{ matrix.zarr-pkg }}" crc32c
       - name: List installed packages
         run: python -m pip list
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,13 @@ jobs:
         run: |
           # TODO: Remove this conditional when pcodec supports Python 3.14
           if [[ "${{ matrix.python-version }}" == "3.14" ]]; then
-            python -m pip install -v ".[test,test_extras,msgpack,google_crc32c,crc32c,zfpy]"
+            python -m pip install -v \
+              --group test --group test_extras \
+              ".[msgpack,google_crc32c,crc32c,zfpy]"
           else
-            python -m pip install -v ".[test,test_extras,msgpack,google_crc32c,crc32c,pcodec,zfpy]"
+            python -m pip install -v \
+              --group test --group test_extras \
+              ".[msgpack,google_crc32c,crc32c,pcodec,zfpy]"
           fi
 
       - name: List installed packages
@@ -85,12 +89,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
       - name: Install numcodecs
         run: |
           if [[ -n "${{ matrix.extras }}" ]]; then
-            python -m pip install -v ".[${{ matrix.extras }},test]"
+            python -m pip install -v --group test ".[${{ matrix.extras }}]"
           else
-            python -m pip install -v ".[test]"
+            python -m pip install -v --group test .
           fi
 
       - name: List installed packages
@@ -135,9 +142,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
       - name: Install numcodecs and Zarr
         run: |
-          python -m pip install -v ".[test,test_extras]" "${{ matrix.zarr-pkg }}" crc32c
+          python -m pip install -v \
+            --group test --group test_extras \
+           . "${{ matrix.zarr-pkg }}" crc32c
+
       - name: List installed packages
         run: python -m pip list
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,10 +16,12 @@ sphinx:
 
 python:
   install:
-    - method: pip
+    - method: uv
+      command: sync
       path: .
-      extra_requirements:
+      groups:
         - docs
+      extras:
         - msgpack
         - zfpy
         - crc32c

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -116,8 +116,8 @@ bootstrap the build dependencies, then install numcodecs in editable mode:
 
 ```
 $ uv venv
-$ uv pip install --group dev
-$ uv pip install --no-build-isolation -e ".[test,test_extras,msgpack]"
+$ uv pip install --group dev --group test --group test_extras
+$ uv pip install --no-build-isolation -e ".[msgpack]"
 ```
 
 The first ``uv pip install`` step bootstraps the build tools into the virtualenv.
@@ -141,8 +141,8 @@ $ python -m venv venv
 $ source venv/bin/activate        # macOS/Linux
 $ # .\venv\Scripts\activate       # Windows
 
-$ pip install --group dev
-$ pip install --no-build-isolation -e ".[test,test_extras,msgpack]"
+$ pip install --group dev --group test --group test_extras
+$ pip install --no-build-isolation -e ".[msgpack]"
 $ pytest -v
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,16 @@ crc32c = [
 google_crc32c = [
     "google-crc32c>=1.5"
 ]
+
+[dependency-groups]
+dev = [
+    "meson-python>=0.17",
+    "meson>=1.6.0",
+    "ninja",
+    "cython>=3.0",
+    "setuptools-scm>=6.2",
+    "numpy>=2",
+]
 docs = [
     "sphinx",
     "sphinx-issues",
@@ -78,16 +88,6 @@ test = [
 test_extras = [
     "importlib_metadata",
     "crc32c",  # TODO: remove once zarr-python does not depend on crc32c anymore
-]
-
-[dependency-groups]
-dev = [
-    "meson-python>=0.17",
-    "meson>=1.6.0",
-    "ninja",
-    "cython>=3.0",
-    "setuptools-scm>=6.2",
-    "numpy>=2",
 ]
 test-zarr-308 = [
     "pytest",
@@ -243,8 +243,8 @@ warn_unused_configs = true
 # meson-python editable installs require build deps (ninja, meson) at runtime for
 # auto-rebuild on import. Skip build isolation so the venv's ninja is used.
 # The "dev" dependency group provides these build tools. Bootstrap with:
-# `uv pip install --group dev` before running
-# `uv pip install --no-build-isolation -e ".[test,test_extras,msgpack]"`.
+# `uv pip install --group dev --group test --group test_extras` before running
+# `uv pip install --no-build-isolation -e ".[msgpack]"`.
 no-build-isolation-package = ["numcodecs"]
 conflicts = [
     # Zarr versions conflict with each other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,22 +62,6 @@ crc32c = [
 google_crc32c = [
     "google-crc32c>=1.5"
 ]
-docs = [
-    "sphinx",
-    "sphinx-issues",
-    "pydata-sphinx-theme",
-    "numpydoc",
-    "myst-parser",
-]
-test = [
-    "coverage",
-    "pytest",
-    "pytest-cov",
-    "pyzstd"
-]
-test_extras = [
-    "importlib_metadata",
-]
 
 [dependency-groups]
 dev = [
@@ -87,8 +71,25 @@ dev = [
     "cython>=3.0",
     "setuptools-scm>=6.2",
     "numpy>=2",
-    "pytest==9.0.3",
 ]
+docs = [
+    "sphinx",
+    "sphinx-issues",
+    "pydata-sphinx-theme",
+    "numpydoc",
+    "myst-parser",
+    "mesonpy",
+]
+test = [
+    "coverage",
+    "pytest==9.0.3",
+    "pytest-cov",
+    "pyzstd"
+]
+test_extras = [
+    "importlib_metadata",
+]
+
 test-zarr-308 = [
     {include-group="dev"},
     "zarr==3.0.8",
@@ -240,8 +241,8 @@ warn_unused_configs = true
 # meson-python editable installs require build deps (ninja, meson) at runtime for
 # auto-rebuild on import. Skip build isolation so the venv's ninja is used.
 # The "dev" dependency group provides these build tools. Bootstrap with:
-# `uv pip install --group dev` before running
-# `uv pip install --no-build-isolation -e ".[test,test_extras,msgpack]"`.
+# `uv pip install --group dev --group test --group test_extras` before running
+# `uv pip install --no-build-isolation -e ".[msgpack]"`.
 no-build-isolation-package = ["numcodecs"]
 conflicts = [
     # Zarr versions conflict with each other


### PR DESCRIPTION
This way test dependencies `test` and `test_extras` won't appear as runtime dependencies in PiPy:
	https://pypi.org/project/numcodecs/

<img width="389" height="312" alt="image" src="https://github.com/user-attachments/assets/dc866889-31db-47a2-9b22-1c778320b277" />

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
