### PR TITLE
Skip test_pyzstd when pyzstd cannot be imported

### DIFF
--- a/tests/test_pyzstd.py
+++ b/tests/test_pyzstd.py
@@ -2,8 +2,10 @@
 
 import numpy as np
 import pytest
-import pyzstd
-from numcodecs.zstd import Zstd
+
+pyzstd = pytest.importorskip("pyzstd")
+
+from numcodecs.zstd import Zstd  # noqa: E402
 
 test_data = [
     b"Hello World!",


### PR DESCRIPTION
On i386 (Alpine, Python 3.14), pyzstd 0.17+ delegates to the stdlib
compression.zstd module, which requires the _zstd C extension that is
not built on that platform. The hard top-level `import pyzstd` turned
this into a collection error, failing the entire test run.

Guard the import with pytest.importorskip so the module is skipped
instead of erroring when pyzstd is unavailable.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

[Description of PR]

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
