### PR TITLE
Add pytest-cov to dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dev = [
     "setuptools-scm>=6.2",
     "numpy>=2",
     "pytest==9.0.3",
+    "pytest-cov",
 ]
 test-zarr-308 = [
     {include-group="dev"},


### PR DESCRIPTION
## Problem

The shared pytest `addopts` in `pyproject.toml` include `--cov=numcodecs --cov-report xml`, so every dependency group that runs pytest needs `pytest-cov`.

After #844 deduped the `test-zarr-*` groups to include the `dev` group, `pytest-cov` was no longer pulled in (the `dev` group only had plain `pytest`). This broke external runners that install those groups — notably zarr-python's "numcodecs zarr3 codec tests" job, which fails with:

```
__main__.py: error: unrecognized arguments: --cov=numcodecs --cov-report
  inifile: .../numcodecs/pyproject.toml
```

(See zarr-developers/zarr-python#3885 checks.)

## Fix

Add `pytest-cov` to the `dev` dependency group. Since every test group includes `dev`, all internal and external runners now get coverage support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)