### PR TITLE
CI: set an explicit python-version for test-crc32c and test-zarr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
           cache: 'pip'
 
       - name: Install numcodecs
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
           cache: 'pip'
 
       - name: Install numcodecs and Zarr


### PR DESCRIPTION
Sets an explicit `python-version: "3.13"` on the setup-python steps of the `test-crc32c` and `test-zarr` jobs, restoring the interpreter they were pinned to before #839. Since that PR, both jobs pass `${{ matrix.python-version }}` to setup-python while neither matrix defines the key, so all six variants have been running on the runner's system Python (3.12.3) — details and log evidence in #855.

Closes #855.

Happy to switch this to a `python-version` matrix axis instead if version × variant coverage is preferred.

TODO:

- [x] Unit tests and/or doctests in docstrings — N/A, CI configuration only
- [x] Tests pass locally — N/A
- [x] Docstrings and API docs for any new/modified user-facing classes and functions — N/A
- [x] Changes documented in docs/release.rst — N/A, no library change
- [x] Docs build locally — N/A
- [ ] GitHub Actions CI passes — awaiting first-contribution run approval
- [x] Test coverage to 100% (Codecov passes) — unaffected

AI assistance was used; the two-line diff and the affected job logs were re-checked by hand.
